### PR TITLE
Stopped generating Package.swift in model generator

### DIFF
--- a/model/index.js
+++ b/model/index.js
@@ -101,11 +101,6 @@ module.exports = generators.Base.extend({
   },
 
   writing: {
-    writePackageSwift: function() {
-      let packageSwift = helpers.generatePackageSwift(this.config);
-      this.fs.write(this.destinationPath('Package.swift'), packageSwift);
-    },
-
     writeModel: function() {
 
       // Convert modelname to valid Swift name (if required)


### PR DESCRIPTION
We now avoid having:
`identical Package.swift`

Fixes: #20