### PR TITLE
Make app generator create models directory

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -261,6 +261,10 @@ module.exports = generators.Base.extend({
       // NOTE(tunniclm): Write a zero-byte file to mark this as a valid project
       // directory
       this.fs.write(this.destinationPath('.swiftservergenerator-project'), '');
+    },
+
+    writeModelsDirectory: function() {
+      this.fs.write(this.destinationPath('models', '.keep'), '');
     }
   },
 


### PR DESCRIPTION
- Previously models directory would only be created once
  the first model had been added using the model generator

Fixes: #36 