### PR TITLE
Fixed issue with NSNumber failing to cast to Int16

### DIFF
--- a/app/templates/ApplicationConfiguration.swift
+++ b/app/templates/ApplicationConfiguration.swift
@@ -48,7 +48,7 @@ public func readConfig(configURL: URL) throws -> Int {
 
     case "cloudant":
         let host = try extractValueFromJSON(fromKey: "host", ofType: .string, fromJSON: storeConfig, defaultingTo: "localhost")
-        let port = Int16(try extractValueFromJSON(fromKey: "port", ofType: .number, fromJSON: storeConfig, defaultingTo: 5984))
+        let port = try extractValueFromJSON(fromKey: "port", ofType: .number, fromJSON: storeConfig, defaultingTo: Int16(5984))
         let secured = try extractValueFromJSON(fromKey: "secured", ofType: .bool, fromJSON: storeConfig, defaultingTo: false)
         let username: String? = try extractValueFromJSON(fromKey: "username", ofType: .string, fromJSON: storeConfig, defaultingTo: nil)
         let password: String? = try extractValueFromJSON(fromKey: "password", ofType: .string, fromJSON: storeConfig, defaultingTo: nil)
@@ -77,7 +77,10 @@ func extractValueFromJSON<T>(fromKey key: String, ofType type: Type, fromJSON js
     guard value.type == type else {
         throw ConfigurationError.typeMismatch(name: key, expectedType: "\(type)", type: "\(value.type)")
     }
-
+    
+    if type == .number, let number = value.rawValue as? NSNumber {
+        return number.int16Value as! T
+    }
     return value.rawValue as! T
 }
 


### PR DESCRIPTION
On Linux machines, including Bluemix, I was getting the following error:

    Could not cast value of type 'Foundation.NSNumber' (0x7febfe1af1c8) to 'Swift.Int' (0x7febfe582148).

To resolve this, I have to handle the casting of NSNumber to an Int16 in a specific way.