### PR TITLE
Property generator correctly changes required field

### DIFF
--- a/property/index.js
+++ b/property/index.js
@@ -119,9 +119,7 @@ module.exports = generators.Base.extend({
         ];
         this.prompt(parameterPrompts, function(parameters) {
           this.properties[answers.name] = { type: parameters.type };
-          if (parameters.required) {
-            this.properties[answers.name].required = true
-          }
+          this.properties[answers.name].required = parameters.required ? true : undefined;
 
           var defaultPrompts = [
             {


### PR DESCRIPTION
We can now change the required field back to false/undefined after it has been set to true

Fixes: #51 