### PR TITLE
Added travis.yml

### DIFF
--- a/.node_tests.sh
+++ b/.node_tests.sh
@@ -1,0 +1,1 @@
+npm test && npm run testint

--- a/.node_tests.sh
+++ b/.node_tests.sh
@@ -1,1 +1,0 @@
-npm test && npm run testint

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,7 @@
 language: node_js
+branches: 
+  only:
+    - master
 matrix:
   include:
    - os: linux
@@ -6,15 +9,15 @@ matrix:
      sudo: required
      node_js: '4'
    - os: linux
-     dist: trust
+     dist: trusty
      sudo: required
      node_js: '6'
    - os: osx
-     osx_image: xcode_8.1
+     osx_image: xcode8.1
      sudo: required
      node_js: '4'
    - os: osx
-     osx_image: xcode_8.1
+     osx_image: xcode8.1
      sudo: required
      node_js: '6'
 before_install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,28 @@
+language: node_js
+matrix:
+  include:
+   - os: linux
+     dist: trusty
+     sudo: required
+     node_js: '4'
+   - os: linux
+     dist: trust
+     sudo: required
+     node_js: '6'
+   - os: osx
+     osx_image: xcode_8.1
+     sudo: required
+     node_js: '4'
+   - os: osx
+     osx_image: xcode_8.1
+     sudo: required
+     node_js: '6'
+before_install:
+    - git clone https://github.com/rob-deans/Package-Builder.git
+script:
+  - ./Package-Builder/build-package.sh -projectDir $TRAVIS_BUILD_DIR -n
+
+env:
+  global:
+    - CXX=g++-4.8
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,8 @@ matrix:
 before_install:
     - git clone https://github.com/IBM-Swift/Package-Builder.git
 script:
-  - ./Package-Builder/build-package.sh -projectDir $TRAVIS_BUILD_DIR -n
+  - ./Package-Builder/install-swift.sh `pwd` 
+  - npm test && npm run testint
 
 env:
   global:

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ matrix:
      sudo: required
      node_js: '6'
 before_install:
-    - git clone https://github.com/rob-deans/Package-Builder.git
+    - git clone https://github.com/IBM-Swift/Package-Builder.git
 script:
   - ./Package-Builder/build-package.sh -projectDir $TRAVIS_BUILD_DIR -n
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,8 +22,10 @@ matrix:
      node_js: '6'
 before_install:
     - git clone https://github.com/IBM-Swift/Package-Builder.git
+before_script:
+    - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then gpg2 --keyserver hkp://keys.gnupg.net --recv-keys 409B6B1796C275462A1703113804BB82D39DC0E3 && rvm get head; fi   
 script:
-  - ./Package-Builder/install-swift.sh `pwd` 
+  - source ./Package-Builder/install-swift.sh `pwd` 
   - npm test && npm run testint
 
 env:


### PR DESCRIPTION
Travis will run 4 builds 2 macOS, 2 linux (trusty) to run the latest node.js version 4 and 6

The `.node_tests.sh` (currently hidden file) allows us to modify what tests will run and any other changes without having to make a PR to `Package-Builder`. 

The `-n` flag is so that it will run the `.node_tests.sh` instead of the current `swift build` etc which breaks the build (Currently `Package-Builder` has not been updated)

Fixes: #57 