### PR TITLE
Fix generating in an empty directory

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -152,6 +152,7 @@ module.exports = generators.Base.extend({
         // When the project name is the same as the current directory,
         // we are assuming the user has already created the project dir
         this.log('working directory is %s', path.basename(this.destinationRoot()));
+        this.destinationSet = true;
         return;
       }
 

--- a/test/integration/app.js
+++ b/test/integration/app.js
@@ -32,7 +32,7 @@ var expected = [
 
 describe('swiftserver:app integration test', function () {
 
-  describe('Application name and directory name are the same', function () {
+  describe('Application name and directory name are the same, not the cwd', function () {
 
     // Swift build is slow so we need to set a longer timeout for the test
     this.timeout(150000);
@@ -54,6 +54,32 @@ describe('swiftserver:app integration test', function () {
 
     it('compiles the application', function () {
       assert.file(process.cwd()+'/.build/debug/notes');
+    });
+  });
+
+  // For this test, don't run the build, we only need to check that the
+  // right files are generated
+  describe('Application name and directory name are the current (empty) directory', function () {
+    var runContext;
+
+    before(function () {
+      // Mock the options, set up an output folder and run the generator
+      runContext = helpers.run(path.join( __dirname, '../../app'))
+        .withPrompts({ name: 'notes' })
+        .withOptions({ 'skip-build': true })
+        .inTmpDir(function(tmpDir) {
+          this.inDir(path.join(tmpDir, 'notes'))
+        });
+        return runContext.toPromise();                        // Get a Promise back when the generator finishes
+    });
+
+    after(function() {
+      //runContext.cleanTestDirectory();
+    });
+
+    it('used the empty directory for the project', function () {
+      assert.equal(path.basename(process.cwd()), 'notes');
+      assert.file(process.cwd()+'/.swiftservergenerator-project');
     });
   });
 

--- a/test/unit/app.js
+++ b/test/unit/app.js
@@ -208,10 +208,7 @@ describe('swiftserver:app', function () {
           name: 'differentAppName',
           dir:  '.'
         });
-        return runContext.toPromise()        // Get a Promise back for when the generator finishes
-        .then(function (dir) {
-          assert.equal(path.basename(process.cwd()), 'currentDir');
-        });
+        return runContext.toPromise();        // Get a Promise back for when the generator finishes
     });
 
     after(function() {
@@ -404,7 +401,6 @@ describe('swiftserver:app', function () {
         .withGenerators(dependentGenerators)
         .withOptions({ testmode:  true })
         .inTmpDir(function (tmpDir) {
-          tmpDir = tmpDir;
           this.inDir(path.join(tmpDir, 'testDir'));
         });
         return runContext.toPromise();        // Get a Promise back for when the generator finishes
@@ -414,21 +410,9 @@ describe('swiftserver:app', function () {
       runContext.cleanTestDirectory();
     });
 
-    it('created and changed into a folder according to dir value', function () {
+    it('used the empty directory for the project', function () {
       assert.equal(path.basename(process.cwd()), 'testDir');
-    });
-
-    it('create a spec object containing the config', function() {
-      var spec = runContext.generator.spec;
-      var expectedSpec = {
-        appType: 'crud',
-        appName: 'testDir',
-        config: {
-          logger: 'helium',
-          port: 8090
-        }
-      };
-      assert.objectContent(spec, expectedSpec);
+      assert(runContext.generator.destinationSet);
     });
   });
 


### PR DESCRIPTION
Problem occurs when generating a project into an existing empty directory.
Instead of generating to the empty directory it creates a new `swiftserver` sub-directory and uses that.

This PR should fix that issue.