### PR TITLE
Set specific tfrank64 MongoKitten version

### DIFF
--- a/refresh/templates/services/mongodb/importDependency.swift
+++ b/refresh/templates/services/mongodb/importDependency.swift
@@ -1,1 +1,1 @@
-.Package(url: "https://github.com/tfrank64/MongoKitten.git", majorVersion: 3),
+.Package(url: "https://github.com/tfrank64/MongoKitten.git", Version(3,0,7)),


### PR DESCRIPTION
This should resolve the build failure that is happening because tfrank64 has newer version tags without the SSL certificate fixes from his fork.