### PR TITLE
Update tfrank64 fork of MongoKitten to 3.0.8

### DIFF
--- a/refresh/templates/services/mongodb/importDependency.swift
+++ b/refresh/templates/services/mongodb/importDependency.swift
@@ -1,1 +1,1 @@
-.Package(url: "https://github.com/tfrank64/MongoKitten.git", Version(3,0,7)),
+.Package(url: "https://github.com/tfrank64/MongoKitten.git", Version(3,0,8)),


### PR DESCRIPTION
Version 3.0.7 wasn't working any more, but 3.0.8 looks good.