### PR TITLE
Added mongodb helpers

### DIFF
--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -353,6 +353,13 @@ function getLocalServiceConfig(serviceType, service) {
                               username: service.username,
                               password: service.password
                             };
+    case ('mongodb'): return {  name: service.name,
+                              type: serviceType,
+                              host: service.host || 'localhost',
+                              port: service.port || 27017,
+                              username: service.username,
+                              password: service.password
+                            };
   }
 };
 
@@ -384,6 +391,19 @@ function getCloudServiceConfig(serviceType, service) {
                                   port: 6397
                               }
                             };
+    case ('mongodb'): return {
+                              name: service.name,
+                              label: exports.getBluemixServiceLabel(serviceType),
+                              tags: [],
+                              plan: service.plan || 'Standard',
+                              credentials: {
+                                  host: service.host || 'localhost',
+                                  url: service.url || '',
+                                  username: service.username || '',
+                                  password: service.password || '',
+                                  port: 27017
+                              }
+                            };
   }
 };
 
@@ -391,6 +411,7 @@ exports.getBluemixServiceLabel = function(serviceType) {
   switch(serviceType) {
     case 'cloudant': return 'cloudantNoSQLDB';
     case 'redis': return 'compose-for-redis';
+    case 'mongodb': return 'compose-for-mongodb';
     default: return serviceType;
   }
 };


### PR DESCRIPTION
The initial mongodb implementation was missing the helpers to convert to the bluemix name and to generate the configs