### PR TITLE
Initial refactor for unbound services

### DIFF
--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -319,23 +319,6 @@ exports.generateLocalConfig = function(specConfig, services) {
   return config;
 }
 
-exports.generateCloudConfig = function(specConfig, services) {
-  var config = {
-    VCAP_SERVICES: {}
-  }
-
-  Object.keys(services).forEach(function(serviceType) {
-    var type = exports.getBluemixServiceLabel(serviceType);
-    config.VCAP_SERVICES[type] = [];
-    services[serviceType].forEach(function(serviceDef) {
-      config.VCAP_SERVICES[type].push(getCloudServiceConfig(serviceType, serviceDef));
-    });
-
-  });
-  return config;
-}
-
-
 function getLocalServiceConfig(serviceType, service) {
   switch (serviceType) {
     case 'cloudant':
@@ -378,6 +361,23 @@ function getLocalServiceConfig(serviceType, service) {
   }
 };
 
+exports.generateCloudConfig = function(specConfig, services) {
+  var config = {
+    vcap: {
+      services: {}
+    }
+  }
+
+  Object.keys(services).forEach(function(serviceType) {
+    var type = exports.getBluemixServiceLabel(serviceType);
+    config.vcap.services[type] = [];
+    services[serviceType].forEach(function(serviceDef) {
+      config.vcap.services[type].push(getCloudServiceConfig(serviceType, serviceDef));
+    });
+  });
+  return config;
+}
+
 function getCloudServiceConfig(serviceType, service) {
   switch (serviceType) {
     case 'cloudant':
@@ -391,7 +391,7 @@ function getCloudServiceConfig(serviceType, service) {
           url: service.url || '',
           username: service.username || '',
           password: service.password || '',
-          port: 5984
+          port: 6984
         }
       };
     case 'redis':

--- a/refresh/templates/common/gitignore
+++ b/refresh/templates/common/gitignore
@@ -2,3 +2,4 @@
 /.build
 /Packages
 /*.xcodeproj
+config.json


### PR DESCRIPTION
Config.json is now in a slightly different format to match swift cfenv 3 

Added config.json to gitignore as the plan is to put credentials from cv env into config.json so that we can run it locally but still have the service running on bluemix - enables testing locally 