### PR TITLE
Manifest configure

### DIFF
--- a/refresh/index.js
+++ b/refresh/index.js
@@ -105,40 +105,39 @@ module.exports = generators.Base.extend({
         this.env.error(chalk.red('No specification for this project'));
       }
 
-      if(this.spec.appType) {
+      if (this.spec.appType) {
         this.appType = this.spec.appType;
       } else {
         this.env.error(chalk.red('App type is missing'));
       }
-      if(this.spec.appName) {
+      if (this.spec.appName) {
           this.projectName = this.spec.appName;
       } else {
           this.env.error(chalk.red('Property appName missing from the specification file spec.json'));
       }
 
       // Bluemix configuration
-      this.bluemix = this.spec.bluemix || undefined;
-
-      if(typeof(this.bluemix) === 'object') {
-        // Validate the values
-        // If the values are not valid remove them from the spec
-        if(typeof(this.bluemix.name) !== 'string') {
-          this.bluemix.name = undefined
+      if (this.spec.bluemix === true) {
+        this.bluemix = {};
+      } else if (typeof(this.spec.bluemix) === 'object') {
+        this.bluemix = {};
+        if (typeof(this.spec.bluemix.name) === 'string') {
+          this.bluemix.name = this.spec.bluemix.name;
         }
-        if((typeof(this.bluemix.host) !== 'string')) {
-            this.bluemix.host = undefined;
+        if (typeof(this.spec.bluemix.host) === 'string') {
+          this.bluemix.host = this.spec.bluemix.host;
         }
-        if((typeof(this.bluemix.domain) !== 'string')) {
-            this.bluemix.domain = undefined;
+        if (typeof(this.spec.bluemix.domain) === 'string') {
+          this.bluemix.domain = this.spec.bluemix.domain;
         }
-        if(typeof(this.bluemix.memory) !== 'string') {
-            this.bluemix.memory = undefined;
+        if (typeof(this.spec.bluemix.memory) === 'string') {
+          this.bluemix.memory = this.spec.bluemix.memory;
         }
-        if(typeof(this.bluemix.diskQuota) !== 'string') {
-          this.bluemix.diskQuota = undefined;
+        if (typeof(this.spec.bluemix.diskQuota) === 'string') {
+          this.bluemix.diskQuota = this.spec.bluemix.diskQuota;
         }
-        if(typeof(this.bluemix.instances) !== 'number') {
-          this.bluemix.instances = undefined;
+        if (typeof(this.spec.bluemix.instances) === 'number') {
+          this.bluemix.instances = this.spec.bluemix.instances;
         }
       }
 
@@ -915,8 +914,7 @@ module.exports = generators.Base.extend({
           services: this.services,
           capabilities: this.capabilities,
           hostSwagger: this.hostSwagger,
-          bluemix: this.bluemix,
-          helpers: helpers }
+          bluemix: this.bluemix }
       );
 
       this.fs.copy(

--- a/refresh/index.js
+++ b/refresh/index.js
@@ -59,7 +59,7 @@ module.exports = generators.Base.extend({
       // TODO Use node-semver? Strip leading non-digits?
       var generatorMajorVersion = this.generatorVersion.split('.')[0];
       var projectGeneratedWithMajorVersion = this.config.get('version').split('.')[0];
-      if (projectGeneratedWithMajorVersion !== generatorMajorVersion) { 
+      if (projectGeneratedWithMajorVersion !== generatorMajorVersion) {
         this.env.error(`Project was generated with a different major version of the generator (project with v${projectGeneratedWithMajorVersion}, current v${generatorMajorVersion})`);
       }
     },
@@ -117,7 +117,20 @@ module.exports = generators.Base.extend({
       }
 
       // Bluemix configuration
-      this.bluemix = (this.spec.bluemix === true);
+      this.bluemix = this.spec.bluemix || undefined;
+
+      if(typeof(this.bluemix) === 'object') {
+        // Validate the values
+        if((typeof(this.bluemix.host) !== 'string')) {
+            this.bluemix.host = undefined;
+        }
+        if((typeof(this.bluemix.domain) !== 'string')) {
+            this.bluemix.domain = undefined;
+        }
+        if(typeof(this.bluemix.memory) !== 'string') {
+            this.bluemix.memory = '128M';
+        }
+      }
 
       // Docker configuration
       this.docker = (this.spec.docker === true);
@@ -884,6 +897,8 @@ module.exports = generators.Base.extend({
     writeBluemixDeploymentFiles: function() {
       if (!this.bluemix) return;
 
+
+
       this.fs.copyTpl(
         this.templatePath('bluemix', 'manifest.yml'),
         this.destinationPath('manifest.yml'),
@@ -892,6 +907,7 @@ module.exports = generators.Base.extend({
           services: this.services,
           capabilities: this.capabilities,
           hostSwagger: this.hostSwagger,
+          bluemix: this.bluemix,
           helpers: helpers }
       );
 

--- a/refresh/index.js
+++ b/refresh/index.js
@@ -900,8 +900,6 @@ module.exports = generators.Base.extend({
     writeBluemixDeploymentFiles: function() {
       if (!this.bluemix) return;
 
-
-
       this.fs.copyTpl(
         this.templatePath('bluemix', 'manifest.yml'),
         this.destinationPath('manifest.yml'),

--- a/refresh/index.js
+++ b/refresh/index.js
@@ -121,6 +121,7 @@ module.exports = generators.Base.extend({
 
       if(typeof(this.bluemix) === 'object') {
         // Validate the values
+        // If the values are not valid remove them from the spec
         if(typeof(this.bluemix.name) !== 'string') {
           this.bluemix.name = undefined
         }
@@ -132,6 +133,12 @@ module.exports = generators.Base.extend({
         }
         if(typeof(this.bluemix.memory) !== 'string') {
             this.bluemix.memory = undefined;
+        }
+        if(typeof(this.bluemix.diskQuota) !== 'string') {
+          this.bluemix.diskQuota = undefined;
+        }
+        if(typeof(this.bluemix.instances) !== 'number') {
+          this.bluemix.instances = undefined;
         }
       }
 

--- a/refresh/index.js
+++ b/refresh/index.js
@@ -121,6 +121,9 @@ module.exports = generators.Base.extend({
 
       if(typeof(this.bluemix) === 'object') {
         // Validate the values
+        if(typeof(this.bluemix.name) !== 'string') {
+          this.bluemix.name = undefined
+        }
         if((typeof(this.bluemix.host) !== 'string')) {
             this.bluemix.host = undefined;
         }
@@ -128,7 +131,7 @@ module.exports = generators.Base.extend({
             this.bluemix.domain = undefined;
         }
         if(typeof(this.bluemix.memory) !== 'string') {
-            this.bluemix.memory = '128M';
+            this.bluemix.memory = undefined;
         }
       }
 

--- a/refresh/templates/bluemix/manifest.yml
+++ b/refresh/templates/bluemix/manifest.yml
@@ -7,7 +7,8 @@ applications:
   random-route: true
 <% } -%>
   memory: <%- bluemix.memory || '128M' %>
-  instances: 1
+  instances: <%- bluemix.instances || 1 %>
+  disk_quota: <%- bluemix.diskQuota || '128M' -%>
   buildpack: swift_buildpack
   command: <%-executableName%> --bind 0.0.0.0:$PORT
 <% if (hostSwagger) { -%>

--- a/refresh/templates/bluemix/manifest.yml
+++ b/refresh/templates/bluemix/manifest.yml
@@ -1,18 +1,3 @@
-<% if (Object.keys(services).length > 0) { -%>
-declared-services:
-<% Object.keys(services).forEach(function(serviceType) { -%>
-<% services[serviceType].forEach(function(service) { -%>
-  <%-service.name%>:
-    label: <%-service.label || helpers.getBluemixServiceLabel(serviceType)%>
-    plan: <%-service.plan || 'Lite'%>
-<% }); -%>
-<% }); -%>
-<% } -%>
-<% if (capabilities.autoscale) { -%>
-  <%-capabilities.autoscale%>:
-    label: Auto-scaling
-    plan: free
-<% } -%>
 applications:
 - name: <%-appName%>
   memory: 128M

--- a/refresh/templates/bluemix/manifest.yml
+++ b/refresh/templates/bluemix/manifest.yml
@@ -1,29 +1,33 @@
 applications:
 - name: <%- bluemix.name || appName %>
-<% if(bluemix.host && bluemix.domain) { -%>
+<% if (bluemix.host) { -%>
   host: <%- bluemix.host %>
-  domain: <%- bluemix.domain %>
 <% } else { -%>
   random-route: true
 <% } -%>
+<% if (bluemix.domain) { -%>
+  domain: <%- bluemix.domain %>
+<% } -%>
   memory: <%- bluemix.memory || '128M' %>
   instances: <%- bluemix.instances || 1 %>
-  disk_quota: <%- bluemix.diskQuota || '128M' -%>
+<% if (bluemix.diskQuota) { -%>
+  disk_quota: <%- bluemix.diskQuota %>
+<% } -%>
   buildpack: swift_buildpack
-  command: <%-executableName%> --bind 0.0.0.0:$PORT
+  command: <%- executableName %> --bind 0.0.0.0:$PORT
 <% if (hostSwagger) { -%>
   env:
     OPENAPI_SPEC: "/swagger/api"
 <% } -%>
 <% if (Object.keys(services).length > 0) { -%>
   services:
-<% Object.keys(services).forEach(function(serviceType) { -%>
-<% services[serviceType].forEach(function(service) { -%>
-  - <%-service.name%>
-<% }); -%>
-<% }); -%>
+<%   Object.keys(services).forEach(function(serviceType) { -%>
+<%     services[serviceType].forEach(function(service) { -%>
+  - <%- service.name %>
+<%     }); -%>
+<%   }); -%>
 <% } -%>
 <% if (capabilities.autoscale) { -%>
-  - <%-capabilities.autoscale%>
+  - <%- capabilities.autoscale %>
 <% } -%>
   timeout: 180

--- a/refresh/templates/bluemix/manifest.yml
+++ b/refresh/templates/bluemix/manifest.yml
@@ -1,8 +1,13 @@
 applications:
-- name: <%-appName%>
-  memory: 128M
-  instances: 1
+- name: <%- bluemix.name || appName %>
+<% if(bluemix.host && bluemix.domain) { -%>
+  host: <%- bluemix.host %>
+  domain: <%- bluemix.domain %>
+<% } else { -%>
   random-route: true
+<% } -%>
+  memory: <%- bluemix.memory || '128M' %>
+  instances: 1
   buildpack: swift_buildpack
   command: <%-executableName%> --bind 0.0.0.0:$PORT
 <% if (hostSwagger) { -%>

--- a/test/unit/refresh.js
+++ b/test/unit/refresh.js
@@ -693,8 +693,8 @@ describe('swiftserver:refresh', function () {
       assert.fileContent('manifest.yml', 'instances: 1');
     });
 
-    it('produces the correct disk quota in the manifest', function () {
-      assert.fileContent('manifest.yml', 'disk_quota: 128M');
+    it('omits disk quota', function () {
+      assert.noFileContent('manifest.yml', 'disk_quota:');
     });
   });
 

--- a/test/unit/refresh.js
+++ b/test/unit/refresh.js
@@ -579,7 +579,9 @@ describe('swiftserver:refresh', function () {
             "name": "test",
             "host": "myhost",
             "domain": "mydomain.net",
-            "memory": "512M"
+            "memory": "512M",
+            "diskQuota": "512M",
+            "instances": 3
           },
           config: {
             logger: 'helium',
@@ -632,6 +634,14 @@ describe('swiftserver:refresh', function () {
     it('produces the correct memory in the manifest', function () {
       assert.fileContent('manifest.yml', 'memory: 512M');
     });
+
+    it('produces the correct number of instances in the manifest', function () {
+      assert.fileContent('manifest.yml', 'instances: 3');
+    });
+
+    it('produces the correct disk quota in the manifest', function () {
+      assert.fileContent('manifest.yml', 'disk_quota: 512M');
+    });
   });
 
   describe('Generate skeleton web application for bluemix with incorrect custom options', function () {
@@ -675,6 +685,14 @@ describe('swiftserver:refresh', function () {
 
     it('produces the default memory amount in the manifest', function () {
       assert.fileContent('manifest.yml', 'memory: 128M');
+    });
+
+    it('produces the correct number of instances in the manifest', function () {
+      assert.fileContent('manifest.yml', 'instances: 1');
+    });
+
+    it('produces the correct disk quota in the manifest', function () {
+      assert.fileContent('manifest.yml', 'disk_quota: 128M');
     });
   });
 

--- a/test/unit/refresh.js
+++ b/test/unit/refresh.js
@@ -566,7 +566,7 @@ describe('swiftserver:refresh', function () {
 
   });
 
-  describe('Generate skeleton web application for bluemix', function () {
+  describe('Generate skeleton web application for bluemix with custom options', function () {
 
     var runContext;
 
@@ -575,7 +575,12 @@ describe('swiftserver:refresh', function () {
         var spec = {
           appType: 'web',
           appName: appName,
-          bluemix: true,
+          bluemix: {
+            "name": "test",
+            "host": "myhost",
+            "domain": "mydomain.net",
+            "memory": "512M"
+          },
           config: {
             logger: 'helium',
             port: 8090
@@ -592,16 +597,16 @@ describe('swiftserver:refresh', function () {
       runContext.cleanTestDirectory();
     });
 
-    it('generates the expected files in the root of the project', function () {
-      assert.file(expectedFiles);
+    it('produces the correct name in the manifest', function () {
+      assert.fileContent('manifest.yml', 'name: test');
     });
 
-    it('generates the main.swift in the correct directory', function() {
-      assert.file('Sources/todoServer/main.swift');
+    it('produces the correct host in the manifest', function () {
+      assert.fileContent('manifest.yml', 'host: myhost');
     });
 
-    if('generates Application.swift', function() {
-      assert.file('Sources/todo/Application.swift')
+    it('produces the correct domain in the manifest', function () {
+      assert.fileContent('manifest.yml', 'domain: mydomain.net');
     });
 
     it('generates web only files and folders', function() {
@@ -624,8 +629,52 @@ describe('swiftserver:refresh', function () {
       assert.noFileContent('manifest.yml', 'OPENAPI_SPEC');
     });
 
-    it('generates the bluemix files', function() {
-      assert.file(expectedBluemixFiles);
+    it('produces the correct memory in the manifest', function () {
+      assert.fileContent('manifest.yml', 'memory: 512M');
+    });
+  });
+
+  describe('Generate skeleton web application for bluemix with incorrect custom options', function () {
+
+    var runContext;
+
+    before(function () {
+        // Set up the spec file which should create all the necessary files for a server
+        var spec = {
+          appType: 'web',
+          appName: appName,
+          bluemix: {
+            "name": {},
+            "host": {},
+            "domain": true,
+            "memory": 512
+          },
+          config: {
+            logger: 'helium',
+            port: 8090
+          }
+        };
+      runContext = helpers.run(path.join( __dirname, '../../refresh'))
+        .withOptions({
+          specObj: spec
+        })
+      return runContext.toPromise();
+    });
+
+    after(function() {
+      runContext.cleanTestDirectory();
+    });
+
+    it('produces the correct name in the manifest based on the app name', function () {
+      assert.fileContent('manifest.yml', `name: ${appName}`);
+    });
+
+    it('produces sets random-route to true in the manifest', function () {
+      assert.fileContent('manifest.yml', 'random-route: true');
+    });
+
+    it('produces the default memory amount in the manifest', function () {
+      assert.fileContent('manifest.yml', 'memory: 128M');
     });
   });
 

--- a/test/unit/refresh.js
+++ b/test/unit/refresh.js
@@ -657,7 +657,9 @@ describe('swiftserver:refresh', function () {
             "name": {},
             "host": {},
             "domain": true,
-            "memory": 512
+            "memory": 512,
+            "instances": "3",
+            "diskQuota": 512
           },
           config: {
             logger: 'helium',


### PR DESCRIPTION
This adds the server name, host etc to the manifest if we receive them from devex

I also remove the `declared services` that was in the manifest but is of no real use now

This branch does not include the fix for `not-used` it is on the branch: https://github.com/IBM-Swift/generator-swiftserver/tree/host_domain_fix