### PR TITLE
Update SwiftMetrics for renamed class

### DIFF
--- a/refresh/templates/capabilities/autoscale/declareCapability.swift
+++ b/refresh/templates/capabilities/autoscale/declareCapability.swift
@@ -1,1 +1,1 @@
-    let _ = AutoScalar(swiftMetricsInstance: sm)
+    let _ = SwiftMetricsBluemix(swiftMetricsInstance: sm)

--- a/refresh/templates/capabilities/metrics/importDependency.swift
+++ b/refresh/templates/capabilities/metrics/importDependency.swift
@@ -1,1 +1,1 @@
-.Package(url: "https://github.com/RuntimeTools/SwiftMetrics.git", majorVersion: 0),
+.Package(url: "https://github.com/RuntimeTools/SwiftMetrics.git", majorVersion: 0, minor: 0),

--- a/test/integration/prompted_nobuild.js
+++ b/test/integration/prompted_nobuild.js
@@ -150,8 +150,8 @@ describe('Prompt and no build integration tests', function () {
       assert.fileContent('Sources/Application/Application.swift', 'import SwiftMetricsBluemix');
     });
 
-    it('Application.swift references AutoScalar', function() {
-      assert.fileContent('Sources/Application/Application.swift', 'AutoScalar');
+    it('Application.swift references SwiftMetricsBluemix', function() {
+      assert.fileContent('Sources/Application/Application.swift', 'SwiftMetricsBluemix(');
     });
   });
 

--- a/test/unit/refresh.js
+++ b/test/unit/refresh.js
@@ -286,7 +286,7 @@ describe('swiftserver:refresh', function () {
       assert.noFileContent(`Sources/${applicationModule}/Application.swift`, 'SwiftMetrics()');
       assert.noFileContent(`Sources/${applicationModule}/Application.swift`, 'SwiftMetricsDash(swiftMetricsInstance');
       assert.noFileContent(`Sources/${applicationModule}/Application.swift`, 'import SwiftMetricsBluemix');
-      assert.noFileContent(`Sources/${applicationModule}/Application.swift`, 'let _ = AutoScalar(swiftMetricsInstance: sm)');
+      assert.noFileContent(`Sources/${applicationModule}/Application.swift`, 'let _ = SwiftMetricsBluemix(swiftMetricsInstance: sm)');
     });
   });
 
@@ -389,7 +389,7 @@ describe('swiftserver:refresh', function () {
       assert.fileContent(`Sources/${applicationModule}/Application.swift`, 'SwiftMetrics()');
       assert.fileContent(`Sources/${applicationModule}/Application.swift`, 'try SwiftMetricsDash(');
       assert.fileContent(`Sources/${applicationModule}/Application.swift`, 'import SwiftMetricsBluemix');
-      assert.fileContent(`Sources/${applicationModule}/Application.swift`, 'AutoScalar(swiftMetricsInstance:');
+      assert.fileContent(`Sources/${applicationModule}/Application.swift`, 'SwiftMetricsBluemix(swiftMetricsInstance:');
     });
   });
 
@@ -427,7 +427,7 @@ describe('swiftserver:refresh', function () {
       assert.noFileContent(`Sources/${applicationModule}/Application.swift`, 'SwiftMetrics()');
       assert.noFileContent(`Sources/${applicationModule}/Application.swift`, 'try SwiftMetricsDash(');
       assert.noFileContent(`Sources/${applicationModule}/Application.swift`, 'import SwiftMetricsBluemix');
-      assert.noFileContent(`Sources/${applicationModule}/Application.swift`, 'AutoScalar(swiftMetricsInstance:');
+      assert.noFileContent(`Sources/${applicationModule}/Application.swift`, 'SwiftMetricsBluemix(swiftMetricsInstance:');
     });
   });
 
@@ -788,7 +788,7 @@ describe('swiftserver:refresh', function () {
       assert.fileContent(`Sources/${applicationModule}/Application.swift`, 'try SwiftMetrics()');
       assert.fileContent(`Sources/${applicationModule}/Application.swift`, 'try SwiftMetricsDash(swiftMetricsInstance');
       assert.fileContent(`Sources/${applicationModule}/Application.swift`, 'import SwiftMetricsBluemix');
-      assert.fileContent(`Sources/${applicationModule}/Application.swift`, 'AutoScalar(swiftMetricsInstance:');
+      assert.fileContent(`Sources/${applicationModule}/Application.swift`, 'SwiftMetricsBluemix(swiftMetricsInstance:');
     });
   });
 
@@ -829,7 +829,7 @@ describe('swiftserver:refresh', function () {
       assert.fileContent(`Sources/${applicationModule}/Application.swift`, 'try SwiftMetrics()');
       assert.fileContent(`Sources/${applicationModule}/Application.swift`, 'try SwiftMetricsDash(swiftMetricsInstance');
       assert.noFileContent(`Sources/${applicationModule}/Application.swift`, 'import SwiftMetricsBluemix');
-      assert.noFileContent(`Sources/${applicationModule}/Application.swift`, 'AutoScalar(swiftMetricsInstance');
+      assert.noFileContent(`Sources/${applicationModule}/Application.swift`, 'SwiftMetricsBluemix(swiftMetricsInstance');
     });
   });
 


### PR DESCRIPTION
Also, set SwiftMetrics version range to 0.0.x to prevent
future breakage while it is pre-1.0.0.