### PR TITLE
Changed redis credentials to only contain uri

### DIFF
--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -432,11 +432,7 @@ function getCloudServiceConfig(serviceType, service) {
         tags: [],
         plan: service.plan || 'Lite',
         credentials: {
-          host: service.credentials.host || 'localhost',
-          url: service.credentials.url || '',
-          username: service.credentials.username || '',
-          password: service.credentials.password || '',
-          port: service.credentials.port || 6397
+          uri: service.credentials.uri || 'redis://:@localhost:6397'
         }
       };
     case 'objectstorage':


### PR DESCRIPTION
The host, password etc gets all the information from the uri and not explicitly from those values inside the credentials object.