### PR TITLE
Dependency fix

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -117,7 +117,7 @@ module.exports = generators.Base.extend({
       var prompts = [
         {
           name: 'name',
-          message: 'What\'s the name of your application?',
+          message: 'What\'s the name of your applicationnnnnnnnnnnnnnnnnnnn?',
           default: this.appname,
           validate: validateAppName
         }

--- a/app/index.js
+++ b/app/index.js
@@ -117,7 +117,7 @@ module.exports = generators.Base.extend({
       var prompts = [
         {
           name: 'name',
-          message: 'What\'s the name of your applicationnnnnnnnnnnnnnnnnnnn?',
+          message: 'What\'s the name of your application?',
           default: this.appname,
           validate: validateAppName
         }

--- a/refresh/templates/capabilities/metrics/importDependency.swift
+++ b/refresh/templates/capabilities/metrics/importDependency.swift
@@ -1,1 +1,1 @@
-        .Package(url: "https://github.com/RuntimeTools/SwiftMetrics.git", majorVersion: 1),
+        .Package(url: "https://github.com/RuntimeTools/SwiftMetrics.git", majorVersion: 1, minor: 0),

--- a/refresh/templates/common/Package.swift
+++ b/refresh/templates/common/Package.swift
@@ -15,7 +15,7 @@ let package = Package(
 <% } else { -%>
         .Package(url: "https://github.com/IBM-Swift/Configuration.git", majorVersion: 0),
 <% } -%>
-<%  if(capabilities["metrics"] === false) { -%>
+<% if(!("metrics" in capabilities)) { -%>
         .Package(url: "https://github.com/IBM-Swift/Kitura.git", majorVersion: 1, minor: 6),
 <% } -%>
 <% Object.keys(services).forEach(function(serviceType) { -%>

--- a/refresh/templates/common/Package.swift
+++ b/refresh/templates/common/Package.swift
@@ -15,7 +15,7 @@ let package = Package(
 <% } else { -%>
         .Package(url: "https://github.com/IBM-Swift/Configuration.git", majorVersion: 0),
 <% } -%>
-<% if(!("metrics" in capabilities)) { -%>
+<% if(capabilities["metrics"] === false || typeof(capabilities["metrics"]) != 'string') { -%>
         .Package(url: "https://github.com/IBM-Swift/Kitura.git", majorVersion: 1, minor: 6),
 <% } -%>
 <% Object.keys(services).forEach(function(serviceType) { -%>

--- a/refresh/templates/common/Package.swift
+++ b/refresh/templates/common/Package.swift
@@ -15,7 +15,7 @@ let package = Package(
 <% } else { -%>
         .Package(url: "https://github.com/IBM-Swift/Configuration.git", majorVersion: 0),
 <% } -%>
-<% if(capabilities["metrics"] === false || typeof(capabilities["metrics"]) != 'string') { -%>
+<% if("undefined" === typeof(capabilities["metrics"])) { -%>
         .Package(url: "https://github.com/IBM-Swift/Kitura.git", majorVersion: 1, minor: 6),
 <% } -%>
 <% Object.keys(services).forEach(function(serviceType) { -%>

--- a/refresh/templates/common/Package.swift
+++ b/refresh/templates/common/Package.swift
@@ -9,12 +9,14 @@ let package = Package(
       Target(name: "<%- executableModule %>", dependencies: [ .Target(name: "<%- applicationModule %>") ])
     ],
     dependencies: [
-        .Package(url: "https://github.com/IBM-Swift/Kitura.git",             majorVersion: 1, minor: 6),
-        .Package(url: "https://github.com/IBM-Swift/HeliumLogger.git",       majorVersion: 1, minor: 6),
+        .Package(url: "https://github.com/IBM-Swift/HeliumLogger.git", majorVersion: 1, minor: 6),
 <% if(bluemix) { -%>
         .Package(url: "https://github.com/IBM-Swift/CloudConfiguration.git", majorVersion: 1),
 <% } else { -%>
-        .Package(url: "https://github.com/IBM-Swift/Configuration.git",      majorVersion: 0, minor: 2),
+        .Package(url: "https://github.com/IBM-Swift/Configuration.git", majorVersion: 0),
+<% } -%>
+<%  if(capabilities["metrics"] === false) { -%>
+        .Package(url: "https://github.com/IBM-Swift/Kitura.git", majorVersion: 1, minor: 6),
 <% } -%>
 <% Object.keys(services).forEach(function(serviceType) { -%>
 <%-  include(`../services/${serviceType}/importDependency.swift`) %>


### PR DESCRIPTION
@tunniclm Given the latest changes I see in the master branch and the tests I ran against it today, it looks like you had already fixed the issue that happens currently in production:

```Resolved version: 1.6.0
Cloning https://github.com/IBM-Swift/Kitura-WebSocket.git
HEAD is now at 93f95a1 IBM-Swift/Kitura#1047 Swift 3.1 changes
Resolved version: 0.8.0
error: The dependency graph could not be satisfied (https://github.com/IBM-Swift/Kitura-net.git)
```

I still went ahead and made a few minor changes to simplify the generated Package.swift and hopefully avoid running into a dependency conflict like the one above: if we include SwiftMetrics in the generated Package.swift file, we should not need to also include Kitura in the file since SwiftMetrics already depends on it. This code update should avoid the possibility of specifying a version of Kitura in the Package.swift file that is different from the one that SwiftMetrics depends on. Let me know if you have any questions.