### PR TITLE
Fix docker using root user on Linux

### DIFF
--- a/refresh/templates/docker/Dockerfile-tools
+++ b/refresh/templates/docker/Dockerfile-tools
@@ -13,3 +13,7 @@ ADD https://raw.githubusercontent.com/IBM-Swift/swift-ubuntu-docker/master/utils
 RUN chmod +x /root/utils/tools-utils.sh
 ADD https://raw.githubusercontent.com/IBM-Swift/swift-ubuntu-docker/master/utils/common-utils.sh /root/utils/common-utils.sh
 RUN chmod +x /root/utils/common-utils.sh
+
+ARG bx_dev_userid=root
+RUN BX_DEV_USERID=$bx_dev_userid
+RUN if [ $bx_dev_userid != "root" ]; then useradd -ms /bin/bash $bx_dev_userid; fi

--- a/refresh/templates/docker/cli-config.yml
+++ b/refresh/templates/docker/cli-config.yml
@@ -1,3 +1,4 @@
+version : 0.0.2
 container-name-run : "<%- cleanAppName.toLowerCase() %>-swift-run"
 container-name-tools : "<%- cleanAppName.toLowerCase() %>-swift-tools"
 image-name-run : "<%- cleanAppName.toLowerCase() %>-swiftrun"


### PR DESCRIPTION
Since we want to map a host volume to our tools docker container when building so that our build results are visible on our host (and to our run docker container), we should not use `root` inside the docker container for building since the resulting files on the host disk end up being mapped to the host root user causing permission issues.

This change updates the tools dockerfile so that it will try and create a new user with which to perform tasks. The Bluemix CLI dev plugin will pass the current user's username to the docker file to use for creating the new user inside the docker image.