### PR TITLE
Split credentials into separate file

### DIFF
--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -386,8 +386,6 @@ function getLocalServiceConfig(serviceType, service) {
         host: service.credentials.host || 'localhost',
         port: service.credentials.port || 5984,
         secured: service.credentials.secured || false,
-        username: service.credentials.username,
-        password: service.credentials.password
       };
     case 'redis':
       return {
@@ -395,8 +393,6 @@ function getLocalServiceConfig(serviceType, service) {
         type: serviceType,
         host: service.credentials.host || 'localhost',
         port: service.credentials.port || 6397,
-        username: service.credentials.username,
-        password: service.credentials.password
       };
     case 'objectstorage':
       return {
@@ -407,8 +403,6 @@ function getLocalServiceConfig(serviceType, service) {
         projectId:  service.credentials.projectId,
         region:     service.credentials.region,
         userId:     service.credentials.userId,
-        username:   service.credentials.username,
-        password:   service.credentials.password,
         domainId:   service.credentials.domainId,
         domainName: service.credentials.domainName,
         role:       service.credentials.role
@@ -597,4 +591,14 @@ exports.getBluemixDefaultPlan = function(serviceType) {
     case 'alertnotification':   return 'Authorized Users';
     default:                    return 'Lite';
   }
+}
+
+exports.removeCredentials = function(services) {
+  Object.keys(services).forEach(function(serviceType) {
+    delete services[serviceType][0].credentials.username;
+    delete services[serviceType][0].credentials.password;
+    delete services[serviceType][0].credentials.uri;
+    delete services[serviceType][0].credentials.secret;
+  });
+  return services;
 }

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -338,6 +338,7 @@ exports.generateServiceName = function(appName, serviceType) {
 };
 
 exports.generateLocalConfig = function(specConfig, services) {
+
   var config = {
     services: {},
     logger: specConfig.logger || 'helium',
@@ -349,9 +350,31 @@ exports.generateLocalConfig = function(specConfig, services) {
     services[serviceType].forEach(function(service) {
       config.services[serviceType].push(getLocalServiceConfig(serviceType, service));
     });
-
   });
+
   return config;
+}
+
+/*
+ * This will generate only the credentials for a particular service
+ * in a similar manner to generating the entire config.
+ * @param {[Object]} List of services to extract the credentials from
+ * @returns {Object} Containing just the username, passwords and the service name
+ */
+exports.generateLocalAuth = function(services) {
+
+  var auth = {
+    services: {}
+  };
+
+  Object.keys(services).forEach(function(serviceType) {
+    auth.services[serviceType] = [];
+    services[serviceType].forEach(function(service) {
+      auth.services[serviceType].push(getLocalCredentials(service));
+    });
+  });
+
+  return auth;
 }
 
 function getLocalServiceConfig(serviceType, service) {
@@ -393,6 +416,17 @@ function getLocalServiceConfig(serviceType, service) {
   }
 };
 
+function getLocalCredentials(service) {
+  // Return an object containing the credentials and the name of the service
+  // Since all local services contain `username` and `password` we can be
+  // agnostic to all of them
+  return {
+    name: service.name,
+    username: service.credentials.username,
+    password: service.credentials.password
+  }
+}
+
 exports.generateCloudConfig = function(specConfig, services) {
   var vcapServices = {};
   Object.keys(services).forEach(function(serviceType) {
@@ -416,7 +450,54 @@ function getCloudServiceConfig(serviceType, service) {
         name: service.name,
         label: service.label || exports.getBluemixServiceLabel(serviceType),
         tags: [],
-        plan: service.plan || exports.getBluemixDefaultPlan(serviceType),
+        plan: service.plan || exports.getBluemixDefaultPlan(serviceType)
+      };
+    case 'redis':
+      return {
+        name: service.name,
+        label: service.label || exports.getBluemixServiceLabel(serviceType),
+        tags: [],
+        plan: service.plan || exports.getBluemixDefaultPlan(serviceType)
+      };
+    case 'objectstorage':
+      return {
+        name: service.name,
+        label: service.label || exports.getBluemixServiceLabel(serviceType),
+        tags: [],
+        plan: service.plan || exports.getBluemixDefaultPlan(serviceType)
+      };
+    case 'appid':
+      return {
+        name: service.name,
+        label: service.label || exports.getBluemixServiceLabel(serviceType),
+        tags: [],
+        plan: service.plan || exports.getBluemixDefaultPlan(serviceType)
+      };
+  }
+};
+
+exports.generateBluemixAuth = function(services) {
+  var vcapServices = {};
+  Object.keys(services).forEach(function(serviceType) {
+    services[serviceType].forEach(function(service) {
+      var serviceLabel = service.label || exports.getBluemixServiceLabel(serviceType);
+      vcapServices[serviceLabel] = vcapServices[serviceLabel] || [];
+      vcapServices[serviceLabel].push(getBluemixCredentials(serviceType, service));
+    });
+  });
+  return {
+    vcap: {
+      services: vcapServices
+    }
+  };
+}
+
+function getBluemixCredentials(serviceType, service) {
+  switch (serviceType) {
+    case 'cloudant':
+      return {
+        name: service.name,
+        label: service.label || exports.getBluemixServiceLabel(serviceType),
         credentials: {
           host: service.credentials.host || 'localhost',
           url: service.credentials.url || '',
@@ -432,8 +513,6 @@ function getCloudServiceConfig(serviceType, service) {
       return {
         name: service.name,
         label: service.label || exports.getBluemixServiceLabel(serviceType),
-        tags: [],
-        plan: service.plan || exports.getBluemixDefaultPlan(serviceType),
         credentials: {
           uri: uri
         }
@@ -442,8 +521,6 @@ function getCloudServiceConfig(serviceType, service) {
       return {
         name: service.name,
         label: service.label || exports.getBluemixServiceLabel(serviceType),
-        tags: [],
-        plan: service.plan || exports.getBluemixDefaultPlan(serviceType),
         credentials: {
           auth_url:   service.credentials.auth_url   || '',
           project:    service.credentials.project    || '',
@@ -461,8 +538,6 @@ function getCloudServiceConfig(serviceType, service) {
       return {
         name: service.name,
         label: service.label || exports.getBluemixServiceLabel(serviceType),
-        tags: [],
-        plan: service.plan || exports.getBluemixDefaultPlan(serviceType),
         credentials: {
           clientId: service.credentials.clientId || '',
           oauthServerUrl: service.credentials.oauthServerUrl || '',
@@ -498,7 +573,7 @@ function getCloudServiceConfig(serviceType, service) {
         }
     };
   }
-};
+}
 
 exports.getBluemixServiceLabel = function(serviceType) {
   switch(serviceType) {

--- a/refresh/index.js
+++ b/refresh/index.js
@@ -651,6 +651,30 @@ module.exports = generators.Base.extend({
         this.fs.writeJSON(filepath, configToWrite);
       });
 
+      // Write out the auth.json, this won't be regenerated again
+      this._ifNotExistsInProject('auth.json', (filepath) => {
+        var authToWrite;
+        if(this.bluemix) {
+          // For now write the whole recap services bit to the auth.json
+          authToWrite = helpers.generateBluemixAuth(this.services);
+        } else {
+          // Non-bluemix
+          // We only write out the credentials, so we need to map the name to the
+          // credentials from the config.json
+          // We only need to know about the services.
+          authToWrite = helpers.generateLocalAuth(this.services);
+        }
+        // authToWrite is an object containing arrays of service credentials
+        // these credentials should be picked up in the swift code and merged
+        // together with the config.
+        //TODO: Only right the file if auth has got values in it?
+        // Write to file
+        this.fs.writeJSON(
+          filepath,
+          authToWrite
+        );
+      }
+
       this._ifNotExistsInProject('.swift-version', (filepath) => {
         this.fs.copy(this.templatePath('common','swift-version'),
                      filepath);

--- a/refresh/index.js
+++ b/refresh/index.js
@@ -655,25 +655,19 @@ module.exports = generators.Base.extend({
       this._ifNotExistsInProject('auth.json', (filepath) => {
         var authToWrite;
         if(this.bluemix) {
-          // For now write the whole recap services bit to the auth.json
           authToWrite = helpers.generateBluemixAuth(this.services);
         } else {
-          // Non-bluemix
-          // We only write out the credentials, so we need to map the name to the
-          // credentials from the config.json
-          // We only need to know about the services.
           authToWrite = helpers.generateLocalAuth(this.services);
         }
-        // authToWrite is an object containing arrays of service credentials
-        // these credentials should be picked up in the swift code and merged
-        // together with the config.
-        //TODO: Only right the file if auth has got values in it?
-        // Write to file
         this.fs.writeJSON(
           filepath,
           authToWrite
         );
       }
+
+      // Remove references to username and password/credentials
+      // before writing the spec file
+      this.services = helpers.removeCredentials(this.services);
 
       this._ifNotExistsInProject('.swift-version', (filepath) => {
         this.fs.copy(this.templatePath('common','swift-version'),

--- a/refresh/templates/common/Application.swift
+++ b/refresh/templates/common/Application.swift
@@ -32,6 +32,7 @@ public var port: Int = 8080
 public func initialize() throws {
 
     manager.load(file: "config.json", relativeFrom: .project)
+           .load(file: "auth.json", relativeFrom: .project)
            .load(.environmentVariables)
 
     port = manager.port

--- a/refresh/templates/common/gitignore
+++ b/refresh/templates/common/gitignore
@@ -2,5 +2,3 @@
 /.build
 /.build-ubuntu
 /Packages
-/config.json
-/spec.json

--- a/refresh/templates/common/gitignore
+++ b/refresh/templates/common/gitignore
@@ -2,3 +2,4 @@
 /.build
 /.build-ubuntu
 /Packages
+/auth.json

--- a/test/integration/app/prompted_nobuild.js
+++ b/test/integration/app/prompted_nobuild.js
@@ -446,7 +446,7 @@ describe('Prompt and no build integration tests for app generator', function () 
       return runContext.toPromise();                        // Get a Promise back when the generator finishes
     });
 
-    it('config.json contains the correct default service credentials for cloudant and redis credentials', function () {
+    it('config.json contains the correct default service config for cloudant and redis credentials', function () {
       var expected = {
         services: {
           cloudant: [{
@@ -496,28 +496,21 @@ describe('Prompt and no build integration tests for app generator', function () 
       return runContext.toPromise();                        // Get a Promise back when the generator finishes
     });
 
-    it('config.json contains the correct service credentials for cloudant and redis credentials', function () {
+    it('auth.json contains the correct service credentials for cloudant and redis credentials', function () {
       var expected = {
         services: {
           cloudant: [{
             name: 'couchdb',
-            type: 'cloudant',
-            host: 'cloudy.ibm.com',
-            port: 4568,
-            secured: true,
             username: 'admin',
             password: 'password'
           }],
           'redis': [{
             name: 'redis',
-            type: 'redis',
-            host: 'reducto.ibm.com',
-            port: 4569,
             password: 'gimble'
           }],
         }
       };
-      assert.jsonFileContent('config.json', expected);
+      assert.jsonFileContent('auth.json', expected);
     });
   });
 
@@ -538,7 +531,7 @@ describe('Prompt and no build integration tests for app generator', function () 
       return runContext.toPromise();                        // Get a Promise back when the generator finishes
     });
 
-    it('config.json contains the correct default service credentials for cloudant, redis, objectstorage, appid, watsonconversation, and alertnotification services', function () {
+    it('auth.json contains the correct default service credentials for cloudant, redis, objectstorage, appid, watsonconversation, and alertnotification services', function () {
       var expected = {
         vcap: {
           services: {
@@ -597,7 +590,7 @@ describe('Prompt and no build integration tests for app generator', function () 
           }
         }
       };
-      assert.jsonFileContent('config.json', expected);
+      assert.jsonFileContent('auth.json', expected);
     });
   });
 
@@ -633,7 +626,7 @@ describe('Prompt and no build integration tests for app generator', function () 
       return runContext.toPromise();                        // Get a Promise back when the generator finishes
     });
 
-    it('config.json contains the credentials specified by the user', function () {
+    it('auth.json contains the credentials specified by the user', function () {
       var expected = {
         vcap: {
           services: {
@@ -692,7 +685,7 @@ describe('Prompt and no build integration tests for app generator', function () 
           }
         }
       };
-      assert.jsonFileContent('config.json', expected);
+      assert.jsonFileContent('auth.json', expected);
     });
   });
 

--- a/test/unit/helpers.js
+++ b/test/unit/helpers.js
@@ -117,8 +117,6 @@ describe('helpers', function () {
                                       projectId:'projectId',
                                       region:'region',
                                       userId:'userId',
-                                      username:'username',
-                                      password:'password',
                                       domainId:'domainId',
                                       domainName:'domainName',
                                       role:'role'}
@@ -129,22 +127,16 @@ describe('helpers', function () {
       var expected = {services:{cloudant:[{type:'cloudant',
                                            host:'host',
                                            port:1234,
-                                           secured:false,
-                                           username:'username',
-                                           password:'password'}],
+                                           secured:false,}],
                                 redis:[{type:'redis',
                                         host:'host',
-                                        port:1234,
-                                        username:'username',
-                                        password:'password'}],
+                                        port:1234,}],
                                 objectstorage:[{type:'objectstorage',
                                                 auth_url:'auth_url',
                                                 project:'project',
                                                 projectId:'projectId',
                                                 region:'region',
                                                 userId:'userId',
-                                                username:'username',
-                                                password:'password',
                                                 domainId:'domainId',
                                                 domainName:'domainName',
                                                 role:'role'}]
@@ -152,6 +144,34 @@ describe('helpers', function () {
       var config = helpers.generateLocalConfig(specConfig, services);
 
       assert.objectContent(config, expected);
+    });
+
+    it('get default local config: supplied credentials do not get set', function() {
+      var specConfig = {};
+      var cloudantCredentials = {host:'host', port:1234,username:'username', password:'password'}
+      var redisCredentials = {host:'host', port:1234,username:'username', password:'password'}
+      var objectstorageCredentials = {auth_url:'auth_url',
+                                      project:'project',
+                                      projectId:'projectId',
+                                      region:'region',
+                                      userId:'userId',
+                                      domainId:'domainId',
+                                      domainName:'domainName',
+                                      role:'role'}
+      var services = {cloudant:[{credentials:cloudantCredentials}],
+                      redis:[{credentials:redisCredentials}],
+                      objectstorage:[{credentials:objectstorageCredentials}]
+                     };
+      var expected = {services:{cloudant:[{username: 'username',
+                                           password: 'password'}],
+                                redis:[{username: 'username',
+                                        password: 'password'}],
+                                objectstorage:[{username: 'username',
+                                                password: 'password'}]
+                               }};
+      var config = helpers.generateLocalConfig(specConfig, services);
+
+      assert.noObjectContent(config, expected);
     });
 
   });
@@ -597,6 +617,60 @@ describe('helpers', function () {
       catch(err) {
         assert.equal(err.message, "Unrecognised type 'undefined'");
       }
+    });
+
+  });
+
+  describe('removeCredentials', function () {
+
+    it('remove all references to usernames and passwords: all services with specified values', function() {
+      var services = {cloudant:[{label:"testcloudant",
+                                 credentials:{host:'host',
+                                              url:'url',
+                                              port:1234}}],
+                      redis:[{label:"testredis",
+                              credentials:{uri:'uri'}}],
+                      objectstorage:[{label:"testobjectstorage",
+                                      credentials:{auth_url:'auth_url',
+                                                   project:'project',
+                                                   projectId:'projectId',
+                                                   region:'region',
+                                                   userId:'userId',
+                                                   domainId:'domainId',
+                                                   domainName:'domainName',
+                                                   role:'role'}}],
+                      appid:[{label:"testappid",
+                              credentials:{clientId:"clientId",
+                                           oauthServerUrl:"oauthServerUrl",
+                                           profilesUrl:"profilesUrl",
+                                           secret:"secret",
+                                           tenantId:"tenantId",
+                                           version:1}}]
+                     };
+      var expected = {}/*{vcap:{services:{testcloudant:[{label:"testcloudant",
+                                                     credentials:{host:"host",
+                                                                  url:"url",
+                                                                  port:1234}}],
+                                      testredis:[{label:"testredis",
+                                                    credentials:{}}],
+                                      testobjectstorage:[{label:"testobjectstorage",
+                                                          credentials:{auth_url:"auth_url",
+                                                                       project:"project",
+                                                                       projectId:"projectId",
+                                                                       region:"region",
+                                                                       userId:"userId",
+                                                                       domainId:"domainId",
+                                                                       domainName:"domainName",
+                                                                       role:"role"}}],
+                                      testappid:[{label:"testappid",
+                                                  credentials:{clientId:"clientId",
+                                                               oauthServerUrl:"oauthServerUrl",
+                                                               profilesUrl:"profilesUrl",
+                                                               tenantId:"tenantId",
+                                                               version:1}}]
+                     }}};*/
+      var spec = helpers.removeCredentials(services);
+      assert.objectContent(spec, expected);
     });
 
   });

--- a/test/unit/helpers.js
+++ b/test/unit/helpers.js
@@ -156,6 +156,64 @@ describe('helpers', function () {
 
   });
 
+  describe('generateLocalAuth', function () {
+    it('get default local auth: no credentials', function() {
+      var services = {};
+      var expected = {};
+      var config = helpers.generateLocalAuth(services);
+
+      assert.objectContent(config, expected);
+    });
+
+    it('get default local config: default credentials', function() {
+      var cloudantCredentials = {}
+      var redisCredentials = {}
+      var objectstorageCredentials = {}
+      var services = {cloudant:[{credentials:cloudantCredentials}],
+                      redis:[{credentials:redisCredentials}],
+                      objectstorage:[{credentials:objectstorageCredentials}]
+                     };
+      var expected = {services:{cloudant:[{}],
+                                redis:[{}],
+                                objectstorage:[{}]}};
+      var config = helpers.generateLocalAuth(services);
+
+      assert.objectContent(config, expected);
+    });
+
+    it('get default local auth: supplied credentials', function() {
+      var cloudantCredentials = {host:'host', port:1234,username:'username', password:'password'}
+      var redisCredentials = {host:'host', port:1234,username:'username', password:'password'}
+      var objectstorageCredentials = {auth_url:'auth_url',
+                                      project:'project',
+                                      projectId:'projectId',
+                                      region:'region',
+                                      userId:'userId',
+                                      username:'username',
+                                      password:'password',
+                                      domainId:'domainId',
+                                      domainName:'domainName',
+                                      role:'role'}
+      var services = {cloudant:[{credentials:cloudantCredentials}],
+                      redis:[{credentials:redisCredentials}],
+                      objectstorage:[{credentials:objectstorageCredentials}]
+                     };
+      var expected = {services:{cloudant:[{
+                                           username:'username',
+                                           password:'password'}],
+                                redis:[{
+                                        username:'username',
+                                        password:'password'}],
+                                objectstorage:[{username:'username',
+                                                password:'password'}]
+                               }};
+      var config = helpers.generateLocalAuth(services);
+
+      assert.objectContent(config, expected);
+    });
+
+  });
+
   describe('generateCloudConfig', function () {
     it('get default cloud config: no services', function() {
       var services = {};
@@ -175,47 +233,16 @@ describe('helpers', function () {
                      };
       var expected = {vcap:{services:{"cloudantNoSQLDB":[{label:"cloudantNoSQLDB",
                                                           tags:[],
-                                                          plan:"Lite",
-                                                          credentials:{host:"localhost",
-                                                                       port:6984}}],
+                                                          plan:"Lite"}],
                                       "compose-for-redis":[{label:"compose-for-redis",
                                                             tags:[],
-                                                            plan:"Standard",
-                                                            credentials:{uri:"redis://admin:@localhost:6397"}}],
+                                                            plan:"Standard"}],
                                       "Object-Storage":[{label:"Object-Storage",
                                                          tags:[],
-                                                         plan:"Free",
-                                                         credentials:{auth_url:"",
-                                                                      project:"",
-                                                                      projectId:"",
-                                                                      region:"",
-                                                                      userId:"",
-                                                                      username:"",
-                                                                      password:"",
-                                                                      domainId:"",
-                                                                      domainName:"",
-                                                                      role:""}}],
+                                                         plan:"Free"}],
                                       "AdvancedMobileAccess":[{label:"AdvancedMobileAccess",
                                                                tags:[],
-                                                               plan:"Graduated tier",
-                                                               credentials:{clientId:"",
-                                                                            oauthServerUrl:"",
-                                                                            profilesUrl:"",
-                                                                            secret:"",
-                                                                            tenantId:"",
-                                                                            version:3}}],
-                                      "WatsonConversation":[{label:"WatsonConversation",
-                                                             tags:[],
-                                                             plan:"Free",
-                                                             credentials:{username:"",
-                                                                          password:"",
-                                                                          url:""}}],
-                                      "AlertNotification":[{label:"AlertNotification",
-                                                            tags:[],
-                                                            plan:"Authorized Users",
-                                                            credentials:{name:"",
-                                                                         password:"",
-                                                                         url:""}}]
+                                                               plan:"Graduated tier"}]
                      }}};
       var config = helpers.generateCloudConfig({}, services);
       assert.objectContent(config, expected);
@@ -251,6 +278,108 @@ describe('helpers', function () {
                                            profilesUrl:"profilesUrl",
                                            secret:"secret",
                                            tenantId:"tenantId",
+                                           version:1}}]
+                     };
+      var expected = {vcap:{services:{testcloudant:[{label:"testcloudant",
+                                                     tags:[],
+                                                     plan:"premium"}],
+                                      testredis:[{label:"testredis",
+                                                    tags:[],
+                                                    plan:"premium"}],
+                                      testobjectstorage:[{label:"testobjectstorage",
+                                                          tags:[],
+                                                          plan:"premium"}],
+                                      testappid:[{label:"testappid",
+                                                  tags:[],
+                                                  plan:"premium"}]
+                     }}};
+      var config = helpers.generateCloudConfig({}, services);
+      assert.objectContent(config, expected);
+    });
+
+  });
+
+  describe('generateBluemixAuth', function () {
+    it('get default cloud auth: no services', function() {
+      var services = {};
+      var expected = {vcap:{services:{}}};
+      var config = helpers.generateCloudConfig({}, services);
+
+      assert.objectContent(config, expected);
+    });
+
+    it('get default cloud auth: all services with default values', function() {
+      var services = {cloudant:[{credentials:{}}],
+                      redis:[{credentials:{}}],
+                      objectstorage:[{credentials:{}}],
+                      appid:[{credentials:{}}]
+                     };
+      var expected = {vcap:{services:{"cloudantNoSQLDB":[{label:"cloudantNoSQLDB",
+                                                          credentials:{host:"localhost",
+                                                                       port:6984}}],
+                                      "compose-for-redis":[{label:"compose-for-redis",
+                                                            credentials:{uri:"redis://admin:@localhost:6397"}}],
+                                      "Object-Storage":[{label:"Object-Storage",
+                                                         credentials:{auth_url:"",
+                                                                      project:"",
+                                                                      projectId:"",
+                                                                      region:"",
+                                                                      userId:"",
+                                                                      username:"",
+                                                                      password:"",
+                                                                      domainId:"",
+                                                                      domainName:"",
+                                                                      role:""}}],
+                                      "AdvancedMobileAccess":[{label:"AdvancedMobileAccess",
+                                                               credentials:{clientId:"",
+                                                                            oauthServerUrl:"",
+                                                                            profilesUrl:"",
+                                                                            secret:"",
+                                                                            tenantId:"",
+                                                                            version:3}}],
+                                      "WatsonConversation":[{label:"WatsonConversation",
+                                                             tags:[],
+                                                             plan:"Free",
+                                                             credentials:{username:"",
+                                                                          password:"",
+                                                                          url:""}}],
+                                      "AlertNotification":[{label:"AlertNotification",
+                                                            tags:[],
+                                                            plan:"Authorized Users",
+                                                            credentials:{name:"",
+                                                                         password:"",
+                                                                         url:""}}]
+                     }}};
+      var config = helpers.generateBluemixAuth(services);
+      assert.objectContent(config, expected);
+    });
+
+    it('get default cloud auth: all services with specified values', function() {
+      var services = {cloudant:[{label:"testcloudant",
+                                 credentials:{host:'host',
+                                              url:'url',
+                                              username:'username',
+                                              password:'password',
+                                              port:1234}}],
+                      redis:[{label:"testredis",
+                              credentials:{uri:'uri'}}],
+                      objectstorage:[{label:"testobjectstorage",
+                                      credentials:{auth_url:'auth_url',
+                                                   project:'project',
+                                                   projectId:'projectId',
+                                                   region:'region',
+                                                   userId:'userId',
+                                                   username:'username',
+                                                   password:'password',
+                                                   domainId:'domainId',
+                                                   domainName:'domainName',
+                                                   role:'role'}}],
+                      appid:[{label:"testappid",
+                              credentials:{clientId:"clientId",
+                                           oauthServerUrl:"oauthServerUrl",
+                                           profilesUrl:"profilesUrl",
+                                           secret:"secret",
+                                           tenantId:"tenantId",
                                            version:1}}],
                       watsonconversation:[{label:"testwatsonconversation",
                                            plan:"free",
@@ -264,20 +393,14 @@ describe('helpers', function () {
                                                        url:"https://api.alerts"}}]
                      };
       var expected = {vcap:{services:{testcloudant:[{label:"testcloudant",
-                                                     tags:[],
-                                                     plan:"premium",
                                                      credentials:{host:"host",
                                                                   url:"url",
                                                                   username:"username",
                                                                   password:"password",
                                                                   port:1234}}],
                                       testredis:[{label:"testredis",
-                                                    tags:[],
-                                                    plan:"premium",
                                                     credentials:{uri:"uri"}}],
                                       testobjectstorage:[{label:"testobjectstorage",
-                                                          tags:[],
-                                                          plan:"premium",
                                                           credentials:{auth_url:"auth_url",
                                                                        project:"project",
                                                                        projectId:"projectId",
@@ -289,8 +412,6 @@ describe('helpers', function () {
                                                                        domainName:"domainName",
                                                                        role:"role"}}],
                                       testappid:[{label:"testappid",
-                                                  tags:[],
-                                                  plan:"premium",
                                                   credentials:{clientId:"clientId",
                                                                oauthServerUrl:"oauthServerUrl",
                                                                profilesUrl:"profilesUrl",
@@ -309,7 +430,7 @@ describe('helpers', function () {
                                                                            password:'password',
                                                                            url:"https://api.alerts"}}]
                      }}};
-      var config = helpers.generateCloudConfig({}, services);
+      var config = helpers.generateBluemixAuth(services);
       assert.objectContent(config, expected);
     });
 

--- a/test/unit/refresh.js
+++ b/test/unit/refresh.js
@@ -668,6 +668,10 @@ describe('swiftserver:refresh', function () {
       assert.file(`Sources/${generatedModule}/${className}CloudantAdapter.swift`)
     });
 
+    it('generates the auth.json file containing the credentials', function() {
+      assert.file('auth.json');
+    });
+
   });
 
   describe('Generated a CRUD application with cloudant without bluemix', function() {


### PR DESCRIPTION
This allows for the config/spec.json to be safely uploaded without credentials being uploaded at the same time.