### PR TITLE
Fix appid deps

### DIFF
--- a/refresh/templates/services/appid/importDependency.swift
+++ b/refresh/templates/services/appid/importDependency.swift
@@ -1,2 +1,3 @@
         .Package(url: "https://github.com/IBM-Swift/Kitura-Request.git", majorVersion: 0, minor: 7),
+        .Package(url: "https://github.com/IBM-Swift/Kitura-Credentials.git", majorVersion: 1, minor: 6),
         .Package(url: "https://github.com/ibm-cloud-security/appid-serversdk-swift.git", majorVersion: 1),


### PR DESCRIPTION
AppID loosened their dependency on Kitura-Credentials which meant that generated projects pick up the latest version `1.7.x` on Swift 3.0.2 causing a dependency graph error. This fix reintroduced the narrower dependency with the generated application's `Package.swift`.