### PR TITLE
Fix integrations test with custom generator dir

### DIFF
--- a/test/integration/model/prompted_nobuild.js
+++ b/test/integration/model/prompted_nobuild.js
@@ -80,7 +80,7 @@ describe('Prompt and no build integration tests for model generator', function()
 
     it('aborts generator with an error', function(){
       assert(error, 'Should throw an error');
-      var expectedError = 'The swiftserver:model generator is not compatible with non-CRUD application types';
+      var expectedError = 'The \\S+?:model generator is not compatible with non-CRUD application types';
       assert(error.match(expectedError), `Error was: "${error}", it should be: "${expectedError}"`);
     });
   });

--- a/test/integration/property/prompted_nobuild.js
+++ b/test/integration/property/prompted_nobuild.js
@@ -69,7 +69,7 @@ describe('Prompt and no build integration tests for property generator', functio
 
     it('aborts generator with an error', function() {
       assert(error, 'Should throw an error');
-      var expectedError = 'The swiftserver:property generator is not compatible with non-CRUD application types';
+      var expectedError = 'The \\S+?:property generator is not compatible with non-CRUD application types';
       assert(error.match(expectedError), `Error was: "${error}", it should be: "${expectedError}"`);
     });
   });


### PR DESCRIPTION
The model and property integration tests would fail with a mismatched
error message that contained the generator name because Yeoman determines
the first part (before the colon) from the install directory of the
generator.

When you clone the generator into a custom directory and npm link it
as you might for development work, this name will be the custom directory
and might not match the usual name ("swiftserver" in this case).