### PR TITLE
Add missing logging

### DIFF
--- a/refresh/templates/crud/Resource.swift
+++ b/refresh/templates/crud/Resource.swift
@@ -79,6 +79,7 @@ public class <%- model.classname %>Resource {
         Log.debug("DELETE \(path)")
         adapter.deleteAll() { error in
             if let error = error {
+                Log.error("InternalServerError during handleDeleteAll: \(error)")
                 response.status(.internalServerError)
             } else {
                 let result = JSON([])


### PR DESCRIPTION
#201 introduced a compile warning that I didn't spot due to not logging out the error message in one of the request handlers (unused variable warning). This PR adds the missing logging.