### PR TITLE
Rework service.version variable extraction

### DIFF
--- a/refresh/templates/extensions/WatsonConversationExtension.swift
+++ b/refresh/templates/extensions/WatsonConversationExtension.swift
@@ -4,10 +4,8 @@ import CloudFoundryConfig
 
 extension Conversation {
 
-   public convenience init(service: WatsonConversationService) {
+   public convenience init(service: WatsonConversationService, version: String) {
 
-        let version = "<%- service.version %>"
-            
         self.init(username: service.username, password: service.password, version: version)
         
     }

--- a/refresh/templates/services/watsonconversation/initializeBluemixService.swift
+++ b/refresh/templates/services/watsonconversation/initializeBluemixService.swift
@@ -1,5 +1,3 @@
     let service = try manager.getWatsonConversationService(name: "<%- service.name %>")
 
-    let version = "<%- service.version %>"
-
-    conversation = Conversation(service: service, version: version)
+    conversation = Conversation(service: service, version: "<%- service.version %>")

--- a/refresh/templates/services/watsonconversation/initializeBluemixService.swift
+++ b/refresh/templates/services/watsonconversation/initializeBluemixService.swift
@@ -1,3 +1,5 @@
     let service = try manager.getWatsonConversationService(name: "<%- service.name %>")
 
-    conversation = Conversation(service: service)
+    let version = "<%- service.version %>"
+
+    conversation = Conversation(service: service, version: version)

--- a/test/unit/refresh.js
+++ b/test/unit/refresh.js
@@ -1262,7 +1262,8 @@ describe('swiftserver:refresh', function () {
         },
         services: {
           watsonconversation: [{
-            name: "myConversationService"
+            name: "myConversationService",
+            version: "4-19-2017"
           }]
         }
       };
@@ -1291,7 +1292,7 @@ describe('swiftserver:refresh', function () {
 
     it('creates the boilerplate to connect to watson conversation service', function() {
       assert.fileContent(`Sources/${applicationModule}/Application.swift`, 'try manager.getWatsonConversationService');
-      assert.fileContent(`Sources/${applicationModule}/Application.swift`, 'conversation = Conversation(service: service, version: version)');
+      assert.fileContent(`Sources/${applicationModule}/Application.swift`, 'conversation = Conversation(service: service, version: "4-19-2017")');
     });
 
   });

--- a/test/unit/refresh.js
+++ b/test/unit/refresh.js
@@ -1291,7 +1291,7 @@ describe('swiftserver:refresh', function () {
 
     it('creates the boilerplate to connect to watson conversation service', function() {
       assert.fileContent(`Sources/${applicationModule}/Application.swift`, 'try manager.getWatsonConversationService');
-      assert.fileContent(`Sources/${applicationModule}/Application.swift`, 'conversation = Conversation(service: service)');
+      assert.fileContent(`Sources/${applicationModule}/Application.swift`, 'conversation = Conversation(service: service, version: version)');
     });
 
   });


### PR DESCRIPTION
@rob-deans The extension file does not have access to the `service` variable, so I moved the processing of `service.version` to the main file and pass it into the extension.