### PR TITLE
Support local cloudant for dev when packaging for Bluemix

### DIFF
--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -422,7 +422,8 @@ function getCloudServiceConfig(serviceType, service) {
           url: service.credentials.url || '',
           username: service.credentials.username || '',
           password: service.credentials.password || '',
-          port: service.credentials.port || 6984
+          secured: service.credentials.secured || false,
+          port: service.credentials.port || 5984
         }
       };
     case 'redis':

--- a/refresh/templates/crud/AdapterFactory.swift
+++ b/refresh/templates/crud/AdapterFactory.swift
@@ -22,7 +22,7 @@ public class AdapterFactory {
       return <%- model.classname %>CloudantAdapter(ConnectionProperties(
           host:     service.host,
           port:     Int16(service.port),
-          secured:  true, // FIXME Fix CloudConfiguration
+          secured:  service.secured,
           username: service.username,
           password: service.password
       ))

--- a/test/integration/app/prompted_nobuild.js
+++ b/test/integration/app/prompted_nobuild.js
@@ -552,7 +552,7 @@ describe('Prompt and no build integration tests for app generator', function () 
                 url: '',
                 username: '',
                 password: '',
-                port: 6984
+                port: 5984
               }
             }],
             'compose-for-redis': [{

--- a/test/unit/helpers.js
+++ b/test/unit/helpers.js
@@ -177,7 +177,7 @@ describe('helpers', function () {
                                                           tags:[],
                                                           plan:"Lite",
                                                           credentials:{host:"localhost",
-                                                                       port:6984}}],
+                                                                       port:5984}}],
                                       "compose-for-redis":[{label:"compose-for-redis",
                                                             tags:[],
                                                             plan:"Standard",


### PR DESCRIPTION
Combined with the following PR to CloudConfiguration:
https://github.com/IBM-Swift/CloudConfiguration/pull/28

this enables you to create a CRUD/Cloudant app that is packaged for Bluemix and it will work seamlessly with a local CouchDB instance for development and then switch to a hosted Cloudant instance when pushed to Bluemix/CloudFoundry.