### PR TITLE
Allow feature branches to be built by travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ branches:
   only:
     - master
     - develop
+    - /^issue.*$/
 node_js:
   - '4'
   - '6'


### PR DESCRIPTION
With this addition to `.travis.yml`, any feature branch prefixed with `issue-` will be built by travis. This is modeled after the Swift-cfenv repo.

@tunniclm  Let me know what you think. 

@rolivieri FYI