### PR TITLE
Data models should be required for POST, PUT and PATCH verbs

### DIFF
--- a/refresh/index.js
+++ b/refresh/index.js
@@ -500,7 +500,7 @@ module.exports = generators.Base.extend({
               'name': 'data',
               'in': 'body',
               'description': 'An object of model property name/value pairs',
-              'required': false,
+              'required': true,
               'schema': {
                 '$ref': '#/definitions/' + modelName
               }
@@ -533,7 +533,7 @@ module.exports = generators.Base.extend({
               'name': 'data',
               'in': 'body',
               'description': 'An object of model property name/value pairs',
-              'required': false,
+              'required': true,
               'schema': {
                 '$ref': '#/definitions/' + modelName
               }
@@ -592,7 +592,7 @@ module.exports = generators.Base.extend({
               'name': 'data',
               'in': 'body',
               'description': 'Model instance data',
-              'required': false,
+              'required': true,
               'schema': {
                 '$ref': '#/definitions/' + modelName
               }


### PR DESCRIPTION
When we develop a CRUD application, the data models for POST (i.e. create), PUT (i.e. replace) and PATCH (i.e. update) mark the model as `required: false` which doesn't look correct.

If you look at the PetStore example (from swagger.io) they mark data model used in the POST/create API as required.