### PR TITLE
Fix second non-root user has privilege failure

### DIFF
--- a/refresh/templates/docker/Dockerfile-tools
+++ b/refresh/templates/docker/Dockerfile-tools
@@ -14,6 +14,9 @@ RUN chmod +x /root/utils/tools-utils.sh
 ADD https://raw.githubusercontent.com/IBM-Swift/swift-ubuntu-docker/master/utils/common-utils.sh /root/utils/common-utils.sh
 RUN chmod +x /root/utils/common-utils.sh
 
-ARG bx_dev_userid=root
+ARG bx_dev_user=root
+ARG bx_dev_userid=1000
+RUN BX_DEV_USER=$bx_dev_user
 RUN BX_DEV_USERID=$bx_dev_userid
-RUN if [ $bx_dev_userid != "root" ]; then useradd -ms /bin/bash $bx_dev_userid; fi
+RUN if [ $bx_dev_userid != "root" ]; then useradd -ms /bin/bash -u $bx_dev_userid $bx_dev_user; fi
+

--- a/refresh/templates/docker/cli-config.yml
+++ b/refresh/templates/docker/cli-config.yml
@@ -1,4 +1,4 @@
-version : 0.0.2
+version : 0.0.3
 container-name-run : "<%- cleanAppName.toLowerCase() %>-swift-run"
 container-name-tools : "<%- cleanAppName.toLowerCase() %>-swift-tools"
 image-name-run : "<%- cleanAppName.toLowerCase() %>-swiftrun"


### PR DESCRIPTION
Fix a bug with the logic added to `Dockerfile-tools` in https://github.com/IBM-Swift/generator-swiftserver/pull/185 where the user id to username mapping was not explicit and wouldn't match expectations under some circumstances.