### PR TITLE
Remove unused rimraf require

### DIFF
--- a/refresh/index.js
+++ b/refresh/index.js
@@ -21,7 +21,6 @@ var path = require('path');
 var chalk = require('chalk');
 var YAML = require('js-yaml');
 var debug = require('debug')('generator-swiftserver:refresh');
-var rimraf = require('rimraf');
 
 var helpers = require('../lib/helpers');
 var actions = require('../lib/actions');


### PR DESCRIPTION
This was causing failures on npm2 since `rimraf` was not in the dependencies (works on newer npm because it is installed for another module).