### PR TITLE
Add node 8 to Travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,9 @@ os:
 dist: trusty
 osx_image: xcode8
 before_install:
-    - if [[ ${TRAVIS_NODE_VERSION:1:1} == "8" ]]; then npm install -g npm@4; fi
+    #- if [[ ${TRAVIS_NODE_VERSION:1:1} == "8" ]]; then npm install -g npm@4; fi
+    - echo $TRAVIS_NODE_VERSION
+    - echo ${TRAVIS_NODE_VERSION:1:1}
     - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then rvm get head; fi
     - git clone https://github.com/IBM-Swift/Package-Builder.git
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,7 @@ os:
 dist: trusty
 osx_image: xcode8
 before_install:
+    - if [[ ${TRAVIS_NODE_VERSION:1:1} == "8" ]]; then npm install -g npm@4; fi
     - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then rvm get head; fi
     - git clone https://github.com/IBM-Swift/Package-Builder.git
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,9 +15,7 @@ os:
 dist: trusty
 osx_image: xcode8
 before_install:
-    #- if [[ ${TRAVIS_NODE_VERSION:1:1} == "8" ]]; then npm install -g npm@4; fi
-    - echo $TRAVIS_NODE_VERSION
-    - echo ${TRAVIS_NODE_VERSION:1:1}
+    - if [[ $TRAVIS_NODE_VERSION == "8" ]]; then npm install -g npm@4; fi
     - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then rvm get head; fi
     - git clone https://github.com/IBM-Swift/Package-Builder.git
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ branches:
 node_js:
   - '4'
   - '6'
+  - '8'
 os:
   - linux
   - osx


### PR DESCRIPTION
Add node v8 to our Travis build matrix and work-around a problem with `npm@5` that was causing incomplete installations (just use `npm@4` until it is fixed).