### PR TITLE
test(unit): add mocks to replace external http calls

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "codecov": "^2.1.0",
     "istanbul": "^0.4.5",
     "mocha": "^3.2.0",
+    "nock": "^9.0.13",
     "nyc": "^10.1.2",
     "yeoman-assert": "^2.2.1",
     "yeoman-test": "^1.5.1"

--- a/test/unit/refresh.js
+++ b/test/unit/refresh.js
@@ -280,18 +280,15 @@ describe('swiftserver:refresh', function () {
     var server;
 
     before(function () {
-        var http = require('http');
-        var swagger = fs.readFileSync(path.join( __dirname, '../resources/person_dino.json'), 'utf8');
-        server = http.createServer(function(request, response) {
-          response.writeHead(200, {'Content-Type': 'application/json' });
-          response.end(swagger);
-        }).listen(8080);
+        nock("http://dino.io")
+          .get("/stuff")
+          .replyWithFile(200, path.join( __dirname, '../resources/person_dino.json'));
 
         // Mock the options, set up an output folder and run the generator
         var spec = {
           appType: 'scaffold',
           appName: appName,
-          fromSwagger: 'http://localhost:8080/stuff',
+          fromSwagger: 'http://dino.io/stuff',
           config: {
             logger: 'helium',
             port: 4567
@@ -319,7 +316,6 @@ describe('swiftserver:refresh', function () {
 
     after(function() {
       runContext.cleanTestDirectory();
-      server.close();
     });
   });
 

--- a/test/unit/refresh.js
+++ b/test/unit/refresh.js
@@ -349,6 +349,44 @@ describe('swiftserver:refresh', function () {
     })
   })
 
+  describe('Generate scaffolded app from a 404 swagger URL', function () {
+    var runContext
+    var error
+
+    before(function () {
+      // Mock the options, set up an output folder and run the generator
+      nock('http://nothing')
+        .get('/here')
+        .reply(404)
+
+      var spec = {
+        appType: 'scaffold',
+        appName: appName,
+        fromSwagger: 'http://nothing/here',
+        config: {
+          logger: 'helium',
+          port: 4567
+        }
+      }
+      runContext = helpers.run(path.join(__dirname, '../../refresh'))
+        .withOptions({
+          specObj: spec
+        })
+      return runContext.toPromise().catch(function (err) {
+        error = err.message
+      })
+    })
+
+    it('aborts generator with an error', function () {
+      assert(error, 'Should throw an error')
+      assert(error.match('failed to load swagger from: http://nothing/here status: 404'), 'did not recieve 404')
+    })
+
+    after(function () {
+      runContext.cleanTestDirectory()
+    })
+  })
+
   describe('Generate scaffolded app from a non-conforming swagger document', function () {
     var swagger = {
       'swagger': '2.0',


### PR DESCRIPTION
Replaced calls to http with calls to the nock library to mock the http responses. includes a fix for Flaky test: Generate scaffolded app from an invalid swagger URL.