### PR TITLE
chore(deps): yeoman-generator@^1.1.1 and update

### DIFF
--- a/build/index.js
+++ b/build/index.js
@@ -15,13 +15,15 @@
  */
 
 'use strict'
-var generators = require('yeoman-generator')
-var chalk = require('chalk')
-var actions = require('../lib/actions')
-var os = require('os')
 var debug = require('debug')('generator-swiftserver:app')
 
-module.exports = generators.Base.extend({
+var Generator = require('yeoman-generator')
+var chalk = require('chalk')
+var os = require('os')
+
+var actions = require('../lib/actions')
+
+module.exports = Generator.extend({
   initializing: {
     config: function () {
       if (!this.options.singleShot) {

--- a/model/index.js
+++ b/model/index.js
@@ -15,9 +15,9 @@
  */
 
 'use strict'
-var generators = require('yeoman-generator')
-
 var debug = require('debug')('generator-swiftserver:model')
+
+var Generator = require('yeoman-generator')
 
 var actions = require('../lib/actions')
 var helpers = require('../lib/helpers')
@@ -25,10 +25,10 @@ var validateRequiredName = helpers.validateRequiredName
 var validateNewModel = helpers.validateNewModel
 var convertModelNametoSwiftClassname = helpers.convertModelNametoSwiftClassname
 
-module.exports = generators.Base.extend({
+module.exports = Generator.extend({
 
   constructor: function () {
-    generators.Base.apply(this, arguments)
+    Generator.apply(this, arguments)
 
     // Allow user to pass the model name into the generator directly
     this.argument('name', {
@@ -51,11 +51,13 @@ module.exports = generators.Base.extend({
     initModelName: function () {
       this.skipPromptingAppName = false
 
-      if (this.name) {
+      if (this.options.name) {
         // User passed a desired model name as an argument
-        var validation = validateRequiredName(this.name)
+        var validation = validateRequiredName(this.options.name)
         if (validation === true) {
           // Desired model name is valid, skip prompting for it later
+          debug('Valid model name provided via command-line argument:', this.options.name)
+          this.name = this.options.name
           this.skipPromptingModelName = true
         } else {
           // Log reason for validation failure, if provided
@@ -63,11 +65,6 @@ module.exports = generators.Base.extend({
           this.log(validation)
         }
       }
-    },
-
-    readConfig: function () {
-      debug('reading config json from: ', this.destinationPath('config.json'))
-      this.config = this.fs.readJSON(this.destinationPath('config.json'))
     }
   },
 
@@ -121,17 +118,12 @@ module.exports = generators.Base.extend({
 
     this.log('Let\'s add some ' + this.name + ' properties now.\n')
     this.log('Enter an empty property name when done.')
-    this.composeWith(
-      'swiftserver:property',
-      {
-        options: {
-          apic: this.options.apic,
-          repeatMultiple: true,
-          model: this.model,
-          'skip-build': this.options['skip-build']
-        }
-      },
-      this.options.testmode ? null : { local: require.resolve('../property') }
-    )
+    var propertyGenerator = this.options.testmode ? 'swiftserver:property' : require.resolve('../property')
+    this.composeWith(propertyGenerator, {
+      apic: this.options.apic,
+      repeatMultiple: true,
+      model: this.model,
+      'skip-build': this.options['skip-build']
+    })
   }
 })

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "chalk": "^1.1.0",
     "debug": "^2.2.0",
     "js-yaml": "^3.4.2",
-    "yeoman-generator": "^0.24.1",
+    "yeoman-generator": "^1.1.1",
     "handlebars": "^4.0.5",
     "bluebird": "^3.5.0",
     "request": "^2.81.0",

--- a/property/index.js
+++ b/property/index.js
@@ -15,19 +15,20 @@
  */
 
 'use strict'
-var generators = require('yeoman-generator')
+var debug = require('debug')('generator-swiftserver:property')
+
+var Generator = require('yeoman-generator')
 
 var actions = require('../lib/actions')
 var helpers = require('../lib/helpers')
-var debug = require('debug')('generator-swiftserver:property')
 var validatePropertyName = helpers.validatePropertyName
 var validateDefaultValue = helpers.validateDefaultValue
 var convertDefaultValue = helpers.convertDefaultValue
 
-module.exports = generators.Base.extend({
+module.exports = Generator.extend({
 
   constructor: function () {
-    generators.Base.apply(this, arguments)
+    Generator.apply(this, arguments)
 
     this.option('skip-build', {
       type: Boolean,
@@ -170,25 +171,19 @@ module.exports = generators.Base.extend({
 
   install: {
     buildDefinitions: function () {
-      this.composeWith(
-        'swiftserver:refresh',
-        {
-          // Pass in the option to refresh to decided whether or not we create the *-product.yml
-          options: {
-            apic: this.options.apic,
-            model: this.model
-          }
-        },
-        this.options.testmode ? null : { local: require.resolve('../refresh') })
+      var refreshGenerator = this.options.testmode ? 'swiftserver:refresh' : require.resolve('../refresh')
+      this.composeWith(refreshGenerator, {
+        // Pass in the option to refresh to decided whether or not we create the *-product.yml
+        apic: this.options.apic,
+        model: this.model
+      })
     },
 
     buildApp: function () {
       if (this.skipBuild || this.options['skip-build']) return
 
-      this.composeWith(
-        'swiftserver:build',
-        {}
-      )
+      var buildGenerator = this.options.testmode ? 'swiftserver:build' : require.resolve('../build')
+      this.composeWith(buildGenerator, {})
     }
   }
 })

--- a/refresh/index.js
+++ b/refresh/index.js
@@ -15,29 +15,28 @@
  */
 
 'use strict'
-
 var debug = require('debug')('generator-swiftserver:refresh')
-var generators = require('yeoman-generator')
-var fs = require('fs')
-var path = require('path')
+
+var Generator = require('yeoman-generator')
 var Promise = require('bluebird')
 var chalk = require('chalk')
 var YAML = require('js-yaml')
 var rimraf = require('rimraf')
 var handlebars = require('handlebars')
+var path = require('path')
+var fs = require('fs')
 
-var helpers = require('../lib/helpers')
 var actions = require('../lib/actions')
-
+var helpers = require('../lib/helpers')
 var swaggerize = require('./fromswagger/swaggerize')
 var sdkHelper = require('../lib/sdkGenHelper')
 var performSDKGenerationAsync = sdkHelper.performSDKGenerationAsync
 var getClientSDKAsync = sdkHelper.getClientSDKAsync
 var getServerSDKAsync = sdkHelper.getServerSDKAsync
 
-module.exports = generators.Base.extend({
+module.exports = Generator.extend({
   constructor: function () {
-    generators.Base.apply(this, arguments)
+    Generator.apply(this, arguments)
 
     // Allow the user to specify where the specification file is
     this.option('specfile', {


### PR DESCRIPTION
When upgrading to `yeoman@1` there were 3 main things to update in the generators:

* `yeoman-generator` no longer exports the property `Base` (you just use the exported object directly, which the doc now suggests you name `Generator` instead of `generators` as prevously)
* `composeWith()` no longer takes a 3rd argument with the `local` setting (instead resolved paths can be passed in the first argument)
* generator command-line arguments are stored in `this.options` instead of `this`, this also affects options passed to `composeWith()` in the 2nd argument which no longer has a separate `options` property for passing options

More info in this blog post: http://yeoman.io/blog/hello-generator-1.0.html