### PR TITLE
fix: reject promise when build tasks fail

### DIFF
--- a/build/index.js
+++ b/build/index.js
@@ -43,17 +43,18 @@ module.exports = Generator.extend({
         var buildProcess = this.spawnCommand('swift', ['build'].concat(opts))
         buildProcess.on('error', (err) => {
           debug(`error spawning command "swift build": ${err}`)
-          this.env.error(chalk.red('Failed to launch build'))
+          reject(new Error(chalk.red('Failed to launch build')))
         })
         buildProcess.on('close', (code, signal) => {
           if (code) {
-            this.env.error(chalk.red('swift build command completed with errors'))
+            reject(new Error(chalk.red('swift build command completed with errors')))
+            return
           }
 
           this.log(chalk.green('swift build command completed'))
           resolve()
         })
-      })
+      }).catch(err => this.env.error(err))
     },
 
     generateXCodeprojFile: function () {
@@ -61,17 +62,18 @@ module.exports = Generator.extend({
         var buildProcess = this.spawnCommand('swift', ['package', 'generate-xcodeproj'])
         buildProcess.on('error', (err) => {
           debug(`error spawning command "swift package generate-xcodeproj": ${err}`)
-          this.env.error(chalk.red('Failed to generate <application>.xcodeproj file'))
+          reject(new Error(chalk.red('Failed to generate <application>.xcodeproj file')))
         })
         buildProcess.on('close', (code, signal) => {
           if (code) {
-            this.env.error(chalk.red('swift package generate-xcodeproj command completed with errors'))
+            reject(new Error(chalk.red('swift package generate-xcodeproj command completed with errors')))
+            return
           }
 
           this.log(chalk.green('generate .xcodeproj command completed'))
           resolve()
         })
-      })
+      }).catch(err => this.env.error(err))
     }
   }
 })

--- a/lib/actions.js
+++ b/lib/actions.js
@@ -40,22 +40,25 @@ exports.ensureRequiredSwiftInstalled = function () {
     })
     child.on('error', (err) => {
       debug(`Could not start swift. ${err}`)
-      this.env.error(chalk.red('Could not start swift. Is it installed and on your PATH?'))
+      reject(new Error(chalk.red('Could not start swift. Is it installed and on your PATH?')))
     })
     child.on('close', (code, signal) => {
       if (code) {
         this.log(chalk.yellow('swift exited with exit code ' + code))
-        this.env.error(chalk.red('Could not start swift. Is it installed and on your PATH?'))
+        reject(new Error(chalk.red('Could not start swift. Is it installed and on your PATH?')))
+        return
       }
       if (!version) {
-        this.env.error(chalk.red('Could not determine swift version'))
+        reject(new Error(chalk.red('Could not determine swift version')))
+        return
       }
       if (version !== '3') {
-        this.env.error(chalk.red('Swift version 3 is required for Swift Server Generator.'))
+        reject(new Error(chalk.red('Swift version 3 is required for Swift Server Generator.')))
+        return
       }
       resolve()
     })
-  })
+  }).catch(err => this.env.error(err))
 }
 
 /**


### PR DESCRIPTION
Previously these errors were being thrown from event handlers that run asynchronously from the Promise chain in which they were declared. To ensure the errors are properly propagated through the promise chain we need to call `reject(err)` instead.