### PR TITLE
chore: add config var for status check interval

### DIFF
--- a/config.js
+++ b/config.js
@@ -1,5 +1,6 @@
 var config = {}
 
 config.sdkGenURL = 'https://mobilesdkgen.ng.bluemix.net/sdkgen/api/generator/'
+config.sdkGenCheckDelay = 3000
 
 module.exports = config

--- a/lib/sdkGenHelper.js
+++ b/lib/sdkGenHelper.js
@@ -74,7 +74,7 @@ exports.performSDKGenerationAsync = function (sdkName, sdkType, fileContent) {
             return generatedID
           } else {
             if (count <= 10) {
-              return Promise.delay(3000).then(() => checkUntilFinished(generatedID, count + 1))
+              return Promise.delay(config.sdkGenCheckDelay).then(() => checkUntilFinished(generatedID, count + 1))
             } else {
               throw new Error(chalk.red('Timeout error, couldn\'t generate SDK within timeout.'))
             }


### PR DESCRIPTION
This will allow us to alter the interval to be very small for unit tests (this will be more relevant when there are more tests that exercise the sdkgen code via nock mocking).