### PR TITLE
chore(deps): add missing standard-version

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "nock": "^9.0.13",
     "nyc": "^10.1.2",
     "standard": "^10.0.2",
+    "standard-version": "^4.2.0",
     "yeoman-assert": "^3.0.0",
     "yeoman-test": "^1.6.0"
   },


### PR DESCRIPTION
The new auto-release script needs `standard-version` as a development dependency but it was not included in https://github.com/IBM-Swift/generator-swiftserver/pull/237