### PR TITLE
feat: enable iOS sdk generation after invoking model generator

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -345,6 +345,7 @@ module.exports = Generator.extend({
 
     promptSwiftServerSwaggerFiles: function () {
       if (this.skipPrompting) return
+      this.log(chalk.magenta('Service prompts'))
 
       var depth = 0
       var prompts = [{
@@ -397,7 +398,6 @@ module.exports = Generator.extend({
       if (this.skipPrompting) return
       if (this.appType !== 'scaffold') return
       if (this.bluemix) return
-      this.log(chalk.magenta('Service prompts'))
 
       var choices = ['CouchDB', 'Redis']
 
@@ -422,7 +422,6 @@ module.exports = Generator.extend({
       if (this.skipPrompting) return
       if (this.appType !== 'scaffold') return
       if (!this.bluemix) return
-      this.log(chalk.magenta('Service prompts'))
 
       var choices = ['Cloudant', 'Redis', 'Object Storage', 'AppID', 'Auto-scaling', 'Watson Conversation', 'Alert Notification', 'Push Notifications']
 
@@ -495,7 +494,6 @@ module.exports = Generator.extend({
       if (this.skipPrompting) return
       if (this.appType !== 'crud') return
       if (!this.bluemix) return
-      this.log(chalk.magenta('Service prompts'))
 
       var choices = ['Auto-scaling']
 

--- a/refresh/index.js
+++ b/refresh/index.js
@@ -1048,7 +1048,7 @@ module.exports = Generator.extend({
         for (var item in this.itemsToIgnore) {
           this.fs.append(
             this.destinationPath('.gitignore'),
-            this.itemsToIgnore[0]
+            this.itemsToIgnore[item]
           )
         }
       }

--- a/refresh/index.js
+++ b/refresh/index.js
@@ -1044,12 +1044,16 @@ module.exports = Generator.extend({
         this.conflicter.force = true
         this.fs.write(swaggerFilename, YAML.safeDump(this.swagger))
 
-        // append items to .gitignore that may have been added through model gen process
+        // Append items to .gitignore that may have been added through model gen process
+        var gitignoreFile = this.fs.read(this.destinationPath('.gitignore'))
         for (var item in this.itemsToIgnore) {
-          this.fs.append(
-            this.destinationPath('.gitignore'),
-            this.itemsToIgnore[item]
-          )
+          // Ensure we only add unique values
+          if (gitignoreFile.indexOf(this.itemsToIgnore[item]) === -1) {
+            this.fs.append(
+              this.destinationPath('.gitignore'),
+              this.itemsToIgnore[item]
+            )
+          }
         }
       }
     },

--- a/test/integration/model/prompted_nobuild.js
+++ b/test/integration/model/prompted_nobuild.js
@@ -143,5 +143,14 @@ describe('Prompt and no build integration tests for model generator', function (
       }
       assert.jsonFileContent('spec.json', expected)
     })
+
+    it('created a iOS SDK zip file', function () {
+      assert.file('test_iOS_SDK.zip')
+    })
+
+    it('added reference to generated iOS SDK to .gitignore', function () {
+      assert.fileContent('.gitignore', '/test_iOS_SDK*')
+      // TODO: ensure only one entry is in .gitignore
+    })
   })
 })

--- a/test/integration/model/prompted_nobuild.js
+++ b/test/integration/model/prompted_nobuild.js
@@ -79,6 +79,7 @@ describe('Prompt and no build integration tests for model generator', function (
   })
 
   describe('Create a new model, creating a new model json file and update the spec.json', function () {
+    this.timeout(300000)
     var runContext
 
     before(function () {

--- a/test/integration/model/prompted_nobuild.js
+++ b/test/integration/model/prompted_nobuild.js
@@ -149,8 +149,10 @@ describe('Prompt and no build integration tests for model generator', function (
     })
 
     it('added reference to generated iOS SDK to .gitignore', function () {
-      assert.fileContent('.gitignore', '/test_iOS_SDK*')
-      // TODO: ensure only one entry is in .gitignore
+      // ensure reference is present and that there is only one reference to iOS SDK
+      var fileContent = fs.readFileSync('.gitignore').toString('utf-8')
+      var occurrences = (fileContent.match(/\/test_iOS_SDK\*/g) || []).length
+      assert.equal(occurrences, 1)
     })
   })
 })

--- a/test/unit/refresh.js
+++ b/test/unit/refresh.js
@@ -71,8 +71,21 @@ describe('swiftserver:refresh', function () {
       `definitions/${appName}.yaml`
     ]
     var runContext
+    var sdkScope
 
     before(function () {
+      sdkScope = nock('https://mobilesdkgen.ng.bluemix.net')
+        .filteringRequestBody(/.*/, '*')
+        .post(`/sdkgen/api/generator/${appName}_iOS_SDK/ios_swift`, '*')
+        .reply(200, { job: { id: 'myid' } })
+        .get('/sdkgen/api/generator/myid/status')
+        .reply(200, { status: 'FINISHED' })
+        .get('/sdkgen/api/generator/myid')
+        .replyWithFile(
+          200,
+          path.join(__dirname, '../resources/dummy_iOS_SDK.zip'),
+          { 'Content-Type': 'application/zip' }
+        )
       var spec = {
         appType: 'crud',
         appName: appName,
@@ -106,7 +119,12 @@ describe('swiftserver:refresh', function () {
     })
 
     after(function () {
+      nock.cleanAll()
       runContext.cleanTestDirectory()
+    })
+
+    it('requested iOS SDK over http', function () {
+      assert(sdkScope.isDone())
     })
 
     it('generates the expected files', function () {
@@ -131,8 +149,21 @@ describe('swiftserver:refresh', function () {
       `definitions/${appName}.yaml`
     ]
     var runContext
+    var sdkScope
 
     before(function () {
+      sdkScope = nock('https://mobilesdkgen.ng.bluemix.net')
+        .filteringRequestBody(/.*/, '*')
+        .post(`/sdkgen/api/generator/${appName}_iOS_SDK/ios_swift`, '*')
+        .reply(200, { job: { id: 'myid' } })
+        .get('/sdkgen/api/generator/myid/status')
+        .reply(200, { status: 'FINISHED' })
+        .get('/sdkgen/api/generator/myid')
+        .replyWithFile(
+          200,
+          path.join(__dirname, '../resources/dummy_iOS_SDK.zip'),
+          { 'Content-Type': 'application/zip' }
+        )
       var spec = {
         appType: 'crud',
         appName: appName,
@@ -167,7 +198,12 @@ describe('swiftserver:refresh', function () {
     })
 
     after(function () {
+      nock.cleanAll()
       runContext.cleanTestDirectory()
+    })
+
+    it('requested iOS SDK over http', function () {
+      assert(sdkScope.isDone())
     })
 
     it('generates the expected files', function () {
@@ -784,8 +820,21 @@ describe('swiftserver:refresh', function () {
 
   describe('Generate a skeleton CRUD application without bluemix', function () {
     var runContext
+    var sdkScope
 
     before(function () {
+      sdkScope = nock('https://mobilesdkgen.ng.bluemix.net')
+        .filteringRequestBody(/.*/, '*')
+        .post(`/sdkgen/api/generator/${appName}_iOS_SDK/ios_swift`, '*')
+        .reply(200, { job: { id: 'myid' } })
+        .get('/sdkgen/api/generator/myid/status')
+        .reply(200, { status: 'FINISHED' })
+        .get('/sdkgen/api/generator/myid')
+        .replyWithFile(
+          200,
+          path.join(__dirname, '../resources/dummy_iOS_SDK.zip'),
+          { 'Content-Type': 'application/zip' }
+        )
         // Set up the spec file which should create all the necessary files for a server
       var spec = {
         appType: 'crud',
@@ -820,7 +869,12 @@ describe('swiftserver:refresh', function () {
     })
 
     after(function () {
+      nock.cleanAll()
       runContext.cleanTestDirectory()
+    })
+
+    it('requested iOS SDK over http', function () {
+      assert(sdkScope.isDone())
     })
 
     it('generates the expected files in the root of the project', function () {
@@ -961,8 +1015,21 @@ describe('swiftserver:refresh', function () {
 
   describe('Generate a skeleton CRUD application for bluemix', function () {
     var runContext
+    var sdkScope
 
     before(function () {
+      sdkScope = nock('https://mobilesdkgen.ng.bluemix.net')
+        .filteringRequestBody(/.*/, '*')
+        .post(`/sdkgen/api/generator/${appName}_iOS_SDK/ios_swift`, '*')
+        .reply(200, { job: { id: 'myid' } })
+        .get('/sdkgen/api/generator/myid/status')
+        .reply(200, { status: 'FINISHED' })
+        .get('/sdkgen/api/generator/myid')
+        .replyWithFile(
+          200,
+          path.join(__dirname, '../resources/dummy_iOS_SDK.zip'),
+          { 'Content-Type': 'application/zip' }
+        )
         // Set up the spec file which should create all the necessary files for a server
       var spec = {
         appType: 'crud',
@@ -997,7 +1064,12 @@ describe('swiftserver:refresh', function () {
     })
 
     after(function () {
+      nock.cleanAll()
       runContext.cleanTestDirectory()
+    })
+
+    it('requested iOS SDK over http', function () {
+      assert(sdkScope.isDone())
     })
 
     it('generates the expected files in the root of the project', function () {
@@ -1160,8 +1232,21 @@ describe('swiftserver:refresh', function () {
 
   describe('Generated a CRUD application with cloudant for bluemix', function () {
     var runContext
+    var sdkScope
 
     before(function () {
+      sdkScope = nock('https://mobilesdkgen.ng.bluemix.net')
+        .filteringRequestBody(/.*/, '*')
+        .post(`/sdkgen/api/generator/${appName}_iOS_SDK/ios_swift`, '*')
+        .reply(200, { job: { id: 'myid' } })
+        .get('/sdkgen/api/generator/myid/status')
+        .reply(200, { status: 'FINISHED' })
+        .get('/sdkgen/api/generator/myid')
+        .replyWithFile(
+          200,
+          path.join(__dirname, '../resources/dummy_iOS_SDK.zip'),
+          { 'Content-Type': 'application/zip' }
+        )
       var spec = {
         appType: 'crud',
         appName: appName,
@@ -1201,7 +1286,12 @@ describe('swiftserver:refresh', function () {
     })
 
     after(function () {
+      nock.cleanAll()
       runContext.cleanTestDirectory()
+    })
+
+    it('requested iOS SDK over http', function () {
+      assert(sdkScope.isDone())
     })
 
     it('generates the extensions required by bluemix', function () {
@@ -1228,8 +1318,21 @@ describe('swiftserver:refresh', function () {
 
   describe('Generated a CRUD application with cloudant without bluemix', function () {
     var runContext
+    var sdkScope
 
     before(function () {
+      sdkScope = nock('https://mobilesdkgen.ng.bluemix.net')
+        .filteringRequestBody(/.*/, '*')
+        .post(`/sdkgen/api/generator/${appName}_iOS_SDK/ios_swift`, '*')
+        .reply(200, { job: { id: 'myid' } })
+        .get('/sdkgen/api/generator/myid/status')
+        .reply(200, { status: 'FINISHED' })
+        .get('/sdkgen/api/generator/myid')
+        .replyWithFile(
+          200,
+          path.join(__dirname, '../resources/dummy_iOS_SDK.zip'),
+          { 'Content-Type': 'application/zip' }
+        )
       var spec = {
         appType: 'crud',
         appName: appName,
@@ -1269,7 +1372,12 @@ describe('swiftserver:refresh', function () {
     })
 
     after(function () {
+      nock.cleanAll()
       runContext.cleanTestDirectory()
+    })
+
+    it('requested iOS SDK over http', function () {
+      assert(sdkScope.isDone())
     })
 
     it('does not generate the extensions required by bluemix', function () {


### PR DESCRIPTION
I might need to lengthen the timeout on model generator tests, but I haven't had any issues thus far.