### PR TITLE
chore: allow master->develop merge to not be ff

### DIFF
--- a/release.sh
+++ b/release.sh
@@ -6,7 +6,7 @@ if [[ $TRAVIS_BRANCH == "master" ]] && [[ $TRAVIS_PULL_REQUEST == "false" ]]; th
   echo "Creating release ${VERSION}" 
   git tag $VERSION && git push origin $VERSION || true
   # Merge back into develop and push those changes
-  git fetch origin && git checkout develop && git merge --ff-only origin/master && git push origin develop
+  git fetch origin && git checkout develop && git merge origin/master && git push origin develop
   # npm publish 
 
   # Deleting the old release branch


### PR DESCRIPTION
If the release script does not run before the next feature PR is merged then the merge back to develop will fail because the release script uses the `--ff-only` option to `git merge`.

It is better to allow the non-ff merge and accept the merge commit in the history rather than block up merging feature PRs (which would be the alternative solution).