### PR TITLE
feat: improve swagger basepath handling

### DIFF
--- a/refresh/index.js
+++ b/refresh/index.js
@@ -786,9 +786,15 @@ module.exports = Generator.extend({
       })
 
       this._ifNotExistsInProject(['Sources', this.applicationModule, 'Application.swift'], (filepath) => {
+        var basepath
         var resources
-        if (this.parsedSwagger && this.parsedSwagger.resources) {
-          resources = Object.keys(this.parsedSwagger.resources)
+        if (this.parsedSwagger) {
+          if (this.parsedSwagger.basepath) {
+            basepath = this.parsedSwagger.basepath
+          }
+          if (this.parsedSwagger.resources) {
+            resources = Object.keys(this.parsedSwagger.resources)
+          }
         }
         this.fs.copyTpl(
           this.templatePath('common', 'Application.swift'),
@@ -802,7 +808,8 @@ module.exports = Generator.extend({
             capabilities: this.capabilities,
             web: this.web,
             hostSwagger: this.hostSwagger,
-            resources: resources
+            resources: resources,
+            basepath: basepath
           }
         )
       })

--- a/refresh/templates/common/Application.swift
+++ b/refresh/templates/common/Application.swift
@@ -24,6 +24,9 @@ import CloudFoundryConfig
 public let router = Router()
 public let manager = ConfigurationManager()
 public var port: Int = 8080
+<% if (basepath) { -%>
+public var basePath = "<%- basepath %>"
+<% } -%>
 
 <% if (Object.keys(services).length > 0) { -%>
 <%   Object.keys(services).forEach(function(serviceType) { -%>

--- a/refresh/templates/fromswagger/Routes.swift.hbs
+++ b/refresh/templates/fromswagger/Routes.swift.hbs
@@ -18,7 +18,7 @@ import SwiftyJSON
 
 func initialize{{resource}}Routes() {
 {{#each routes}}
-    router.{{this.method}}("{{../basepath}}{{this.route}}") { request, response, next in
+    router.{{this.method}}("{{#if ../basepath}}\(basePath){{/if}}{{this.route}}") { request, response, next in
         response.send(json: [:])
         next()
     }

--- a/test/resources/productSwagger.yaml
+++ b/test/resources/productSwagger.yaml
@@ -1,0 +1,112 @@
+swagger: '2.0'
+
+info:
+  version: "0.0.1"
+  title: Products API
+
+consumes:
+  - text/plain
+
+produces:
+  - application/json
+
+paths:
+  /products:
+    get:
+      tags:
+        - products
+      operationId: getAll
+      description: Get all products
+      responses:
+        200:
+          $ref: '#/responses/getAllProducts'
+    post:
+      tags:
+        - products
+      operationId: add
+      description: Add new product
+      parameters:
+        - $ref: '#/parameters/productNameParam'
+      responses:
+        200:
+          $ref: '#/responses/getOneProduct'
+
+  /products/{id}:
+    get:
+      tags:
+        - products
+      operationId: get
+      description: Get product by ID
+      parameters:
+        - $ref: '#/parameters/idParam'
+      responses:
+        200:
+          $ref: '#/responses/getOneProduct'
+
+    delete:
+      tags:
+        - products
+      operationId: delete
+      description: Delete product by ID
+      parameters:
+        - $ref: '#/parameters/idParam'
+      responses:
+        200:
+          $ref: '#/responses/getOneProduct'
+
+    put:
+      tags:
+        - products
+      operationId: update
+      description: Update product by ID
+      parameters:
+        - $ref: '#/parameters/idParam'
+        - $ref: '#/parameters/productNameParam'
+      responses:
+        200:
+          $ref: '#/responses/getOneProduct'
+
+
+definitions:
+  product:
+    type: object
+    description: A product object
+    required:
+      - id
+      - name
+    properties:
+      id:
+        type: integer
+        format: int64
+      name:
+        type: string
+
+responses:
+  getOneProduct:
+    description: One product
+    schema:
+      $ref: '#/definitions/product'
+
+  getAllProducts:
+    description: List of all products
+    schema:
+      type: array
+      items:
+        $ref: '#/definitions/product'
+
+parameters:
+  idParam:
+    name: id
+    in: path
+    description: Product ID
+    required: true
+    type: integer
+    format: int64
+
+  productNameParam:
+    name: productName
+    in: body
+    description: Product name
+    required: true
+    schema:
+      type: string

--- a/test/unit/refresh.js
+++ b/test/unit/refresh.js
@@ -404,7 +404,7 @@ describe('swiftserver:refresh', function () {
       assert.file(expectedSourceFiles)
       assert.fileContent(`Sources/${applicationModule}/Application.swift`, 'initializePersonsRoutes(')
       assert.fileContent(`Sources/${applicationModule}/Application.swift`, 'initializeDinosaursRoutes(')
-      assert.fileContent(`Sources/${applicationModule}/Routes/PersonsRoutes.swift`, 'router.get("/basepath/persons"')
+      assert.fileContent(`Sources/${applicationModule}/Routes/PersonsRoutes.swift`, 'router.get("\\(basePath)/persons"')
     })
   })
 
@@ -500,7 +500,7 @@ describe('swiftserver:refresh', function () {
       assert.file(expectedSourceFiles)
       assert.fileContent(`Sources/${applicationModule}/Application.swift`, 'initializePersonsRoutes(')
       assert.fileContent(`Sources/${applicationModule}/Application.swift`, 'initializeDinosaursRoutes(')
-      assert.fileContent(`Sources/${applicationModule}/Routes/PersonsRoutes.swift`, 'router.get("/basepath/persons"')
+      assert.fileContent(`Sources/${applicationModule}/Routes/PersonsRoutes.swift`, 'router.get("\\(basePath)/persons"')
     })
 
     after(function () {

--- a/test/unit/refresh.js
+++ b/test/unit/refresh.js
@@ -509,6 +509,44 @@ describe('swiftserver:refresh', function () {
     })
   })
 
+  describe('Generate scaffolded app from valid swagger but no basepath', function () {
+    var runContext
+
+    before(function () {
+      // Mock the options, set up an output folder and run the generator
+      var spec = {
+        appType: 'scaffold',
+        appName: appName,
+        fromSwagger: path.join(__dirname, '../resources/productSwagger.yaml'),
+        config: {
+          logger: 'helium',
+          port: 4567
+        }
+      }
+      runContext = helpers.run(path.join(__dirname, '../../refresh'))
+        .withOptions({
+          specObj: spec
+        })
+      return runContext.toPromise()
+    })
+
+    it('generates the swift files', function () {
+      var expectedSourceFiles = [
+        `Sources/${applicationModule}/Application.swift`,
+        `Sources/${applicationModule}/Routes/ProductsRoutes.swift`,
+        `Sources/${executableModule}/main.swift`
+      ]
+      assert.file(expectedSourceFiles)
+      assert.fileContent(`Sources/${applicationModule}/Application.swift`, 'initializeProductsRoutes(')
+      assert.fileContent(`Sources/${applicationModule}/Routes/ProductsRoutes.swift`, 'router.get("/products"')
+      assert.fileContent(`Sources/${applicationModule}/Routes/ProductsRoutes.swift`, 'router.get("/products/:id"')
+    })
+
+    after(function () {
+      runContext.cleanTestDirectory()
+    })
+  })
+
   describe('Generate scaffolded app experiencing a service status failure', function () {
     var runContext
     var error


### PR DESCRIPTION
If swagger basePath is found, create a basePath variable and add the the value from the swagger. Withing the route handling code, the basePath variable is concatenated to the remaining part of the route that was specified in the swagger. This makes the code easier to read, especially if the basepath is very long. In the case where no basepath is specified, the variable is not created.