### PR TITLE
fix: default toolchain type link

### DIFF
--- a/refresh/index.js
+++ b/refresh/index.js
@@ -154,6 +154,7 @@ module.exports = Generator.extend({
         this.env.error(chalk.red(`Property appType is invalid: ${this.spec.appType}`))
       }
       this.appType = this.spec.appType
+      this.repoType = this.spec.repoType || 'link'
 
       // App name
       if (this.spec.appName) {
@@ -1276,7 +1277,8 @@ module.exports = Generator.extend({
         this.fs.copyTpl(
           this.templatePath('bluemix', 'toolchain.yml'),
           filepath,
-          { appName: this.projectName }
+          { appName: this.projectName,
+            repoType: this.repoType }
         )
       })
 

--- a/refresh/templates/bluemix/toolchain.yml
+++ b/refresh/templates/bluemix/toolchain.yml
@@ -13,7 +13,7 @@ repo:
   service_id: githubpublic
   parameters:
     repo_url: "{{repository}}"
-    type: clone
+    type: <%-repoType%>
     has_issues: true
 
 # Pipelines

--- a/refresh/templates/bluemix/toolchain.yml
+++ b/refresh/templates/bluemix/toolchain.yml
@@ -13,7 +13,7 @@ repo:
   service_id: githubpublic
   parameters:
     repo_url: "{{repository}}"
-    type: link
+    type: clone
     has_issues: true
 
 # Pipelines


### PR DESCRIPTION
This fix addresses this [GHE issue], which requests that the `toolchain.yml` default to `type: clone` for all interactions, with the exception of using the `bx dev enable` command, where it should be `type: link`.  That requite change has been made in the appropriate starter kit & cloud-enablement. 