### PR TITLE
fix: removing manifest health definitions and tests

### DIFF
--- a/refresh/index.js
+++ b/refresh/index.js
@@ -272,10 +272,10 @@ module.exports = Generator.extend({
       }
 
       // Define health-check-type and health-check-http-endpoint
-      if (this.healthcheck) {
+      /* if (this.healthcheck) {
         this.bluemix.server['health-check-type'] = 'http'
         this.bluemix.server['health-check-http-endpoint'] = '/health'
-      }
+      } */
 
       // Define OPENAPI_SPEC
       if (this.hostSwagger) {

--- a/test/integration/app/prompted_nobuild.js
+++ b/test/integration/app/prompted_nobuild.js
@@ -112,12 +112,12 @@ describe('Integration tests (prompt no build) for swiftserver:app', function () 
         ])
       })
 
-      it('cloudfoundry manifest defines health check details', function () {
+      /* it('cloudfoundry manifest defines health check details', function () {
         assert.fileContent([
           [ cloudFoundryManifestFile, 'health-check-type: http' ],
           [ cloudFoundryManifestFile, 'health-check-http-endpoint: /health' ]
         ])
-      })
+      }) */
 
       it('cloudfoundry manifest does not define OPENAPI_SPEC', function () {
         assert.noFileContent(cloudFoundryManifestFile, 'OPENAPI_SPEC')

--- a/test/unit/refresh.js
+++ b/test/unit/refresh.js
@@ -344,12 +344,12 @@ describe('Unit tests for swiftserver:refresh', function () {
           ])
         })
 
-        it('cloudfoundry manifest defines health check details', function () {
+        /* it('cloudfoundry manifest defines health check details', function () {
           assert.fileContent([
             [ cloudFoundryManifestFile, 'health-check-type: http' ],
             [ cloudFoundryManifestFile, 'health-check-http-endpoint: /health' ]
           ])
-        })
+        }) */
 
         it('cloudfoundry manifest defines OPENAPI_SPEC environment variable', function () {
           assert.fileContent(cloudFoundryManifestFile, 'OPENAPI_SPEC : "/swagger/api"')
@@ -718,12 +718,12 @@ describe('Unit tests for swiftserver:refresh', function () {
         ])
       })
 
-      it('cloudfoundry manifest defines health check details', function () {
+      /* it('cloudfoundry manifest defines health check details', function () {
         assert.fileContent([
           [ cloudFoundryManifestFile, 'health-check-type: http' ],
           [ cloudFoundryManifestFile, 'health-check-http-endpoint: /health' ]
         ])
-      })
+      }) */
 
       it('cloudfoundry manifest does not define OPENAPI_SPEC', function () {
         assert.noFileContent(cloudFoundryManifestFile, 'OPENAPI_SPEC')


### PR DESCRIPTION
This PR comments out:
+ manifest healthcheck porperty definitions
+ tests that validate the successful assignment of these properties