### PR TITLE
Add Prometheus metrics endpoint

### DIFF
--- a/refresh/templates/common/Metrics.swift
+++ b/refresh/templates/common/Metrics.swift
@@ -1,17 +1,21 @@
 import SwiftMetrics
 import SwiftMetricsDash
+import SwiftMetricsPrometheus
 import LoggerAPI
 
 var swiftMetrics: SwiftMetrics?
 var swiftMetricsDash: SwiftMetricsDash?
+var swiftMetricsPrometheus: SwiftMetricsPrometheus?
 
 func initializeMetrics(app: App) {
     do {
         let metrics = try SwiftMetrics()
         let dashboard = try SwiftMetricsDash(swiftMetricsInstance: metrics, endpoint: app.router)
+        let prometheus = try SwiftMetricsPrometheus(swiftMetricsInstance: metrics, endpoint: app.router)
 
         swiftMetrics = metrics
         swiftMetricsDash = dashboard
+        swiftMetricsPrometheus = prometheus
         Log.info("Initialized metrics.")
     } catch {
         Log.warning("Failed to initialize metrics: \(error)")


### PR DESCRIPTION
Add support for SwiftMetricsPrometheus into Metrics.swift by default.

The Prometheus endpoint configuration for Kube is already in the Helm chart, so we just need to add the SwiftMetricsPromethues boilerplate code into Metrics.swift.