### PR TITLE
feat: refactor to use bluemix object to specify services

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -61,20 +61,20 @@ module.exports = Generator.extend({
     })
   },
 
-  _isTrue: function (value) {
-    return (value === true || value === 'true')
-  },
-
   initializing: {
     ensureNotInProject: actions.ensureNotInProject,
 
     initSpec: function () {
+      function isTrue (value) {
+        return (value === true || value === 'true')
+      }
+
       if (this.options.bluemix) {
         this.skipPrompting = true
 
         var appName = this.options.bluemix.name
-        var metrics = this._isTrue(this.options.metrics) || undefined
-        var docker = this._isTrue(this.options.docker) || undefined
+        var metrics = isTrue(this.options.metrics) || undefined
+        var docker = isTrue(this.options.docker) || undefined
 
         var web = (this.appType === 'web' || this.appType === 'bff' || undefined)
         var hostSwagger = (this.appType === 'bff' || undefined)
@@ -532,7 +532,7 @@ module.exports = Generator.extend({
         // NOTE(tunniclm): no need to do anything for memory it is the default
         // if no crudservice is passed to the refresh generator
         if (answer.store === 'Cloudant') {
-          this._addService('cloudant', 'crudDataStore', true)
+          this._addService('cloudant', 'crudDataStore')
           this.crudservice = 'crudDataStore'
         }
       })
@@ -651,8 +651,6 @@ module.exports = Generator.extend({
       })
     },
 
-    // TODO: and so on (be careful about whether each service is a
-    // 1-element array or just stored directly)
     promptConfigureRedis: function () {
       if (this.skipPrompting) return
       if (!this.servicesToConfigure) return
@@ -783,6 +781,8 @@ module.exports = Generator.extend({
       if (this.skipPrompting) return
       if (!this.servicesToConfigure) return
       if (!this.servicesToConfigure.conversation) return
+
+      this.log()
       this.log('Configure Watson Conversation')
       var prompts = [
         { name: 'watsonConversationName', message: 'Enter name (blank for default):' },

--- a/app/index.js
+++ b/app/index.js
@@ -61,11 +61,42 @@ module.exports = Generator.extend({
     })
   },
 
+  _isTrue: function (value) {
+    return (value === true || value === 'true')
+  },
+
   initializing: {
     ensureNotInProject: actions.ensureNotInProject,
 
     initSpec: function () {
-      if (this.options.init) {
+      if (this.options.bluemix) {
+        this.skipPrompting = true
+
+        var appName = this.options.bluemix.name
+        var metrics = this._isTrue(this.options.metrics) || undefined
+        var docker = this._isTrue(this.options.docker) || undefined
+
+        var web = (this.appType === 'web' || this.appType === 'bff' || undefined)
+        var hostSwagger = (this.appType === 'bff' || undefined)
+        var exampleEndpoints = (this.appType === 'bff' || undefined)
+        var swaggerUI = (this.appType === 'bff' || undefined)
+        var healthcheck = (this.appType !== 'blank')
+
+        this.spec = {
+          appName: appName,
+          appType: 'scaffold',
+          appDir: '.',
+          docker: docker,
+          web: web,
+          hostSwagger: hostSwagger,
+          exampleEndpoints: exampleEndpoints,
+          swaggerUI: swaggerUI,
+          bluemix: JSON.parse(this.options.bluemix),
+          metrics: metrics,
+          repoType: 'clone',
+          healthcheck: healthcheck
+        }
+      } else if (this.options.init) {
         // User passed the --init flag, so no prompts, just generate basic default scaffold
         this.destinationSet = true
         this.skipPrompting = true
@@ -75,7 +106,7 @@ module.exports = Generator.extend({
           appName: this.appname,
           docker: true,
           metrics: true,
-          services: {}
+          bluemix: {}
         }
       } else if (this.options.spec) {
         try {
@@ -126,13 +157,26 @@ module.exports = Generator.extend({
           this.appname = 'app'
         }
       }
+    },
+
+    initForPrompting: function () {
+      if (this.skipPrompting) return
+      // initialize for prompting
+      this.bluemix = { server: {} }
     }
   },
 
-  _addService: function (serviceType, service) {
+  _addService: function (serviceType, serviceName) {
     this.services = this.services || {}
-    this.services[serviceType] = this.services[serviceType] || []
-    this.services[serviceType].push(service)
+    var service = {
+      serviceInfo: {
+        label: helpers.getBluemixServiceLabel(serviceType),
+        name: serviceName,
+        plan: helpers.getBluemixDefaultPlan(serviceType)
+      }
+    }
+    if (helpers.isThisServiceAnArray(serviceType)) service = [service]
+    this.services[serviceType] = service
   },
 
   prompting: {
@@ -434,36 +478,34 @@ module.exports = Generator.extend({
       }]
       return this.prompt(prompts).then((answers) => {
         if (answers.services.indexOf('Cloudant / CouchDB') !== -1) {
-          this._addService('cloudant', { name: generateServiceName(this.appname, 'Cloudant') })
+          this._addService('cloudant', generateServiceName(this.appname, 'Cloudant'))
         }
         if (answers.services.indexOf('Redis') !== -1) {
-          this._addService('redis', { name: generateServiceName(this.appname, 'Redis') })
+          this._addService('redis', generateServiceName(this.appname, 'Redis'))
         }
         if (answers.services.indexOf('MongoDB') !== -1) {
-          this._addService('mongodb', { name: generateServiceName(this.appname, 'MongoDB') })
+          this._addService('mongodb', generateServiceName(this.appname, 'MongoDB'))
         }
         if (answers.services.indexOf('PostgreSQL') !== -1) {
-          this._addService('postgresql', { name: generateServiceName(this.appname, 'PostgreSQL') })
+          this._addService('postgresql', generateServiceName(this.appname, 'PostgreSQL'))
         }
         if (answers.services.indexOf('Object Storage') !== -1) {
-          this._addService('objectstorage', { name: generateServiceName(this.appname, 'ObjectStorage') })
+          this._addService('objectStorage', generateServiceName(this.appname, 'ObjectStorage'))
         }
         if (answers.services.indexOf('AppID') !== -1) {
-          this._addService('appid', { name: generateServiceName(this.appname, 'AppID') })
+          this._addService('auth', generateServiceName(this.appname, 'AppID'))
         }
         if (answers.services.indexOf('Watson Conversation') !== -1) {
-          this._addService('watsonconversation', { name: generateServiceName(this.appname, 'WatsonConversation') })
+          this._addService('conversation', generateServiceName(this.appname, 'WatsonConversation'))
         }
         if (answers.services.indexOf('Alert Notification') !== -1) {
-          this._addService('alertnotification', { name: generateServiceName(this.appname, 'AlertNotification') })
+          this._addService('alertNotification', generateServiceName(this.appname, 'AlertNotification'))
         }
         if (answers.services.indexOf('Push Notifications') !== -1) {
-          this._addService('pushnotifications', {
-            name: generateServiceName(this.appname, 'PushNotifications'),
-            region: 'US_SOUTH' })
+          this._addService('push', generateServiceName(this.appname, 'PushNotifications'))
         }
         if (answers.services.indexOf('Auto-scaling') !== -1) {
-          this._addService('autoscaling', { name: generateServiceName(this.appname, 'AutoScaling') })
+          this._addService('autoscaling', generateServiceName(this.appname, 'AutoScaling'))
         }
       })
     },
@@ -490,7 +532,7 @@ module.exports = Generator.extend({
         // NOTE(tunniclm): no need to do anything for memory it is the default
         // if no crudservice is passed to the refresh generator
         if (answer.store === 'Cloudant') {
-          this._addService('cloudant', { name: 'crudDataStore' })
+          this._addService('cloudant', 'crudDataStore', true)
           this.crudservice = 'crudDataStore'
         }
       })
@@ -511,7 +553,7 @@ module.exports = Generator.extend({
       }]
       return this.prompt(prompts).then((answers) => {
         if (answers.services.indexOf('Auto-scaling') !== -1) {
-          this._addService('autoscaling', { name: generateServiceName(this.appname, 'AutoScaling') })
+          this._addService('autoscaling', generateServiceName(this.appname, 'AutoScaling'))
         }
       })
     },
@@ -530,12 +572,12 @@ module.exports = Generator.extend({
           case 'redis': return 'Redis'
           case 'mongodb': return 'MongoDB'
           case 'postgresql': return 'PostgreSQL'
-          case 'objectstorage': return 'Object Storage'
-          case 'appid': return 'AppID'
+          case 'objectStorage': return 'Object Storage'
+          case 'auth': return 'AppID'
           case 'autoscaling': return 'Auto-scaling'
-          case 'watsonconversation': return 'Watson Conversation'
-          case 'alertnotification': return 'Alert Notification'
-          case 'pushnotifications': return 'Push Notifications'
+          case 'conversation': return 'Watson Conversation'
+          case 'alertNotification': return 'Alert Notification'
+          case 'push': return 'Push Notifications'
           default:
             self.env.error(chalk.red(`Internal error: unknown service type ${serviceType}`))
         }
@@ -570,10 +612,10 @@ module.exports = Generator.extend({
           message: 'Enter name (blank for default):',
           when: (answers) => this.appType !== 'crud'
         },
-        { name: 'cloudantHost', message: 'Enter host name:' },
+        { name: 'cloudantHost', message: 'Enter host name (blank for localhost):' },
         {
           name: 'cloudantPort',
-          message: 'Enter port:',
+          message: 'Enter port (blank for default):',
           validate: (port) => validatePort(port),
           filter: (port) => (port ? parseInt(port) : port)
         },
@@ -593,17 +635,24 @@ module.exports = Generator.extend({
         }
       ]
       return this.prompt(prompts).then((answers) => {
-        this.services.cloudant[0].name = answers.cloudantName || this.services.cloudant[0].name
-        this.services.cloudant[0].credentials = {
+        var cloudantService = this.services.cloudant[0]
+        this.services.cloudant[0] = {
           host: answers.cloudantHost || undefined,
           port: answers.cloudantPort || undefined,
           secured: answers.cloudantSecured || undefined,
           username: answers.cloudantUsername || undefined,
-          password: answers.cloudantPassword || undefined
+          password: answers.cloudantPassword || undefined,
+          serviceInfo: {
+            label: cloudantService.serviceInfo.label,
+            name: answers.cloudantName || cloudantService.serviceInfo.name,
+            plan: cloudantService.serviceInfo.plan
+          }
         }
       })
     },
 
+    // TODO: and so on (be careful about whether each service is a
+    // 1-element array or just stored directly)
     promptConfigureRedis: function () {
       if (this.skipPrompting) return
       if (!this.servicesToConfigure) return
@@ -625,11 +674,16 @@ module.exports = Generator.extend({
         { name: 'redisPassword', message: 'Enter password:', type: 'password' }
       ]
       return this.prompt(prompts).then((answers) => {
-        this.services.redis[0].name = answers.redisName || this.services.redis[0].name
-        this.services.redis[0].credentials = {
+        var redisService = this.services.redis
+        this.services.redis = {
           host: answers.redisHost || undefined,
           port: answers.redisPort || undefined,
-          password: answers.redisPassword || undefined
+          password: answers.redisPassword || undefined,
+          serviceInfo: {
+            label: redisService.serviceInfo.label,
+            name: answers.redisName || redisService.serviceInfo.name,
+            plan: redisService.serviceInfo.plan
+          }
         }
       })
     },
@@ -656,12 +710,17 @@ module.exports = Generator.extend({
         { name: 'mongodbDatabase', message: 'Enter database name:' }
       ]
       return this.prompt(prompts).then((answers) => {
-        this.services.mongodb[0].name = answers.mongodbName || this.services.mongodb[0].name
-        this.services.mongodb[0].credentials = {
+        var mongoService = this.services.mongodb
+        this.services.mongodb = {
           host: answers.mongodbHost || undefined,
           port: answers.mongodbPort || undefined,
           password: answers.mongodbPassword || undefined,
-          database: answers.mongodbDatabase || undefined
+          database: answers.mongodbDatabase || undefined,
+          serviceInfo: {
+            label: mongoService.serviceInfo.label,
+            name: answers.mongodbName || mongoService.serviceInfo.name,
+            plan: mongoService.serviceInfo.plan
+          }
         }
       })
     },
@@ -689,13 +748,18 @@ module.exports = Generator.extend({
         { name: 'postgresqlDatabase', message: 'Enter database name:' }
       ]
       return this.prompt(prompts).then((answers) => {
-        this.services.postgresql[0].name = answers.postgresqlName || this.services.postgresql[0].name
-        this.services.postgresql[0].credentials = {
+        var postgreService = this.services.postgresql
+        this.services.postgresql = {
           host: answers.postgresqlHost || undefined,
           port: answers.postgresqlPort || undefined,
           username: answers.postgresqlUsername || undefined,
           password: answers.postgresqlPassword || undefined,
-          database: answers.postgresqlDatabase || undefined
+          database: answers.postgresqlDatabase || undefined,
+          serviceInfo: {
+            label: postgreService.serviceInfo.label,
+            name: answers.postgresqlName || postgreService.serviceInfo.name,
+            plan: postgreService.serviceInfo.plan
+          }
         }
       })
     },
@@ -711,16 +775,14 @@ module.exports = Generator.extend({
         { name: 'autoscalingName', message: 'Enter name (blank for default):' }
       ]
       return this.prompt(prompts).then((answers) => {
-        this.services.autoscaling[0].name = answers.autoscalingName || this.services.autoscaling[0].name
+        this.services.autoscaling.serviceInfo.name = answers.autoscalingName || this.services.autoscaling.serviceInfo.name
       })
     },
 
     promptConfigureWatsonConversation: function () {
       if (this.skipPrompting) return
       if (!this.servicesToConfigure) return
-      if (!this.servicesToConfigure.watsonconversation) return
-
-      this.log()
+      if (!this.servicesToConfigure.conversation) return
       this.log('Configure Watson Conversation')
       var prompts = [
         { name: 'watsonConversationName', message: 'Enter name (blank for default):' },
@@ -729,11 +791,16 @@ module.exports = Generator.extend({
         { name: 'watsonConversationUrl', message: 'Enter url (blank for none):' }
       ]
       return this.prompt(prompts).then((answers) => {
-        this.services.watsonconversation[0].name = answers.watsonConversationName || this.services.watsonconversation[0].name
-        this.services.watsonconversation[0].credentials = {
+        var watsonService = this.services.conversation
+        this.services.conversation = {
           username: answers.watsonConversationUsername || undefined,
           password: answers.watsonConversationPassword || undefined,
-          url: answers.watsonConversationUrl || undefined
+          url: answers.watsonConversationUrl || undefined,
+          serviceInfo: {
+            label: watsonService.serviceInfo.label,
+            name: answers.watsonConversationName || watsonService.name,
+            plan: watsonService.serviceInfo.plan
+          }
         }
       })
     },
@@ -741,8 +808,7 @@ module.exports = Generator.extend({
     promptConfigureAlertNotification: function () {
       if (this.skipPrompting) return
       if (!this.servicesToConfigure) return
-      if (!this.servicesToConfigure.alertnotification) return
-
+      if (!this.servicesToConfigure.alertNotification) return
       this.log()
       this.log('Configure Alert Notification')
       var prompts = [
@@ -752,11 +818,16 @@ module.exports = Generator.extend({
         { name: 'alertNotificationUrl', message: 'Enter url (blank for none):' }
       ]
       return this.prompt(prompts).then((answers) => {
-        this.services.alertnotification[0].name = answers.alertNotificationName || this.services.alertnotification[0].name
-        this.services.alertnotification[0].credentials = {
+        var alertNotificationService = this.services.alertNotification
+        this.services.alertNotification = {
           name: answers.alertNotificationUsername || undefined,
           password: answers.alertNotificationPassword || undefined,
-          url: answers.alertNotificationUrl || undefined
+          url: answers.alertNotificationUrl || undefined,
+          serviceInfo: {
+            label: alertNotificationService.serviceInfo.label,
+            name: answers.alertNotificationName || alertNotificationService.serviceInfo.name,
+            plan: alertNotificationService.plan
+          }
         }
       })
     },
@@ -764,7 +835,7 @@ module.exports = Generator.extend({
     promptConfigurePushNotifications: function () {
       if (this.skipPrompting) return
       if (!this.servicesToConfigure) return
-      if (!this.servicesToConfigure.pushnotifications) return
+      if (!this.servicesToConfigure.push) return
 
       this.log()
       this.log('Configure Push Notifications')
@@ -782,15 +853,20 @@ module.exports = Generator.extend({
         }
       ]
       return this.prompt(prompts).then((answers) => {
-        this.services.pushnotifications[0].name = answers.pushNotificationsName || this.services.pushnotifications[0].name
-        this.services.pushnotifications[0].credentials = {
+        var pushService = this.services.push
+        this.services.push = {
           appGuid: answers.pushNotificationsAppGuid || undefined,
-          appSecret: answers.pushNotificationsAppSecret || undefined
+          appSecret: answers.pushNotificationsAppSecret || undefined,
+          serviceInfo: {
+            label: pushService.serviceInfo.label,
+            name: answers.pushNotificationsName || pushService.serviceInfo.name,
+            plan: pushService.serviceInfo.plan
+          }
         }
         switch (answers.pushNotificationsRegion) {
-          case 'US South': this.services.pushnotifications[0].region = 'US_SOUTH'; break
-          case 'United Kingdom': this.services.pushnotifications[0].region = 'UK'; break
-          case 'Sydney': this.services.pushnotifications[0].region = 'SYDNEY'; break
+          case 'United Kingdom': this.bluemix.server.domain = 'eu-gb.bluemix.net'; break
+          case 'Sydney': this.bluemix.server.domain = 'au-syd.bluemix.net'; break
+          case 'US South': this.bluemix.server.domain = 'ng.bluemix.net'; break
           default:
             this.env.error(chalk.red(`Internal error: unknown region ${answers.pushNotificationsRegion}`))
         }
@@ -800,7 +876,7 @@ module.exports = Generator.extend({
     promptConfigureObjectStorage: function () {
       if (this.skipPrompting) return
       if (!this.servicesToConfigure) return
-      if (!this.servicesToConfigure.objectstorage) return
+      if (!this.servicesToConfigure.objectStorage) return
 
       this.log()
       this.log('Configure Object Storage')
@@ -820,8 +896,8 @@ module.exports = Generator.extend({
         { name: 'objectstoragePassword', message: 'Enter password:', type: 'password' }
       ]
       return this.prompt(prompts).then((answers) => {
-        this.services.objectstorage[0].name = answers.objectstorageName || this.services.objectstorage[0].name
-        this.services.objectstorage[0].credentials = {
+        var objectStorageService = this.services.objectStorage[0]
+        this.services.objectStorage[0] = {
           /*
           auth_url:   answers.objectstorageAuth_url || undefined,
           domainId:   answers.objectstorageDomainId || undefined,
@@ -833,7 +909,12 @@ module.exports = Generator.extend({
           region: answers.objectstorageRegion || undefined,
           projectId: answers.objectstorageProjectId || undefined,
           userId: answers.objectstorageUserId || undefined,
-          password: answers.objectstoragePassword || undefined
+          password: answers.objectstoragePassword || undefined,
+          serviceInfo: {
+            label: objectStorageService.serviceInfo.label,
+            name: answers.objectstorageName || objectStorageService.serviceInfo.name,
+            plan: objectStorageService.serviceInfo.plan
+          }
         }
       })
     },
@@ -841,8 +922,7 @@ module.exports = Generator.extend({
     promptConfigureAppID: function () {
       if (this.skipPrompting) return
       if (!this.servicesToConfigure) return
-      if (!this.servicesToConfigure.appid) return
-
+      if (!this.servicesToConfigure.auth) return
       this.log()
       this.log('Configure AppID')
       var prompts = [
@@ -852,11 +932,16 @@ module.exports = Generator.extend({
         { name: 'appidSecret', message: 'Enter secret:', type: 'password' }
       ]
       return this.prompt(prompts).then((answers) => {
-        this.services.appid[0].name = answers.appIDName || this.services.appid[0].name
-        this.services.appid[0].credentials = {
+        var appIdService = this.services.auth
+        this.services.auth = {
           tenantId: answers.appidTenantId || undefined,
           clientId: answers.appidClientId || undefined,
-          secret: answers.appidSecret || undefined
+          secret: answers.appidSecret || undefined,
+          serviceInfo: {
+            label: appIdService.serviceInfo.label,
+            name: answers.appIDName || appIdService.serviceInfo.name,
+            plan: appIdService.serviceInfo.plan
+          }
         }
       })
     }
@@ -866,8 +951,15 @@ module.exports = Generator.extend({
     if (this.skipPrompting) return
     // NOTE(tunniclm): This spec object may not exploit all possible functionality,
     // some may only be available via non-prompting route.
-    if (this.autoscale) this._addService('autoscale', { name: this.autoscale })
-
+    if (this.services) {
+      this.bluemix.server.services = []
+      Object.keys(this.services).forEach(serviceType => {
+        var services = Array.isArray(this.services[serviceType]) ? this.services[serviceType] : [this.services[serviceType]]
+        services.forEach(service => {
+          this.bluemix.server.services.push(service.serviceInfo.name)
+        })
+      })
+    }
     this.spec = {
       appType: this.appType,
       appName: this.appname,
@@ -879,8 +971,8 @@ module.exports = Generator.extend({
       hostSwagger: this.hostSwagger || undefined,
       swaggerUI: this.swaggerUI || undefined,
       metrics: this.metrics || undefined,
-      services: this.services || {},
-      crudservice: this.crudservice
+      crudservice: this.crudservice,
+      bluemix: Object.assign(this.bluemix, this.services) || {}
     }
   },
 

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -578,10 +578,7 @@ exports.resourceNameFromPath = function (thepath) {
 }
 
 exports.isThisServiceAnArray = function (serviceType) {
-  if (serviceType === 'cloudant' || serviceType === 'objectStorage') {
-    return true
-  }
-  return false
+  return (serviceType === 'cloudant' || serviceType === 'objectStorage')
 }
 
 exports.validateServiceFields = function (serviceType, service) {

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -380,8 +380,8 @@ function sanitizeCredentialsAndFillInDefaults (serviceType, service) {
         password: '',
         secured: false
       }
-      if (service.credentials.url) {
-        var parsedURL = url.parse(service.credentials.url)
+      if (service.url) {
+        var parsedURL = url.parse(service.url)
         if (parsedURL.host) defaults.host = parsedURL.hostname
         if (parsedURL.port) defaults.port = parsedURL.port
         if (parsedURL.auth) {
@@ -393,96 +393,96 @@ function sanitizeCredentialsAndFillInDefaults (serviceType, service) {
           defaults.secured = (parsedURL.protocol === 'https')
         }
       }
-      if (service.credentials.host) defaults.url.hostname = service.credentials.host
-      if (service.credentials.port) defaults.url.port = service.credentials.port
-      if (service.credentials.secured) defaults.url.protocol = 'https'
-      if (service.credentials.username || service.credentials.password) {
+      if (service.host) defaults.url.hostname = service.host
+      if (service.port) defaults.url.port = service.port
+      if (service.secured) defaults.url.protocol = 'https'
+      if (service.username || service.password) {
         defaults.url.auth = [
-          service.credentials.username,
-          service.credentials.password
+          service.username,
+          service.password
         ].join(':')
       }
       return {
-        host: service.credentials.host || defaults.host,
-        url: service.credentials.url || url.format(defaults.url),
-        username: service.credentials.username || defaults.username,
-        password: service.credentials.password || defaults.password,
-        secured: service.credentials.secured || defaults.secured,
-        port: service.credentials.port || defaults.port
+        host: service.host || defaults.host,
+        url: service.url || url.format(defaults.url),
+        username: service.username || defaults.username,
+        password: service.password || defaults.password,
+        secured: service.secured || defaults.secured,
+        port: service.port || defaults.port
       }
     case 'redis':
       var defaultRedisURI = { protocol: 'redis', auth: ':', hostname: 'localhost', port: 6397, slashes: true }
-      if (service.credentials.host) defaultRedisURI.hostname = service.credentials.host
-      if (service.credentials.port) defaultRedisURI.port = service.credentials.port
-      if (service.credentials.password) defaultRedisURI.auth = `:${service.credentials.password}`
+      if (service.host) defaultRedisURI.hostname = service.host
+      if (service.port) defaultRedisURI.port = service.port
+      if (service.password) defaultRedisURI.auth = `:${service.password}`
       return {
-        uri: service.credentials.uri || url.format(defaultRedisURI)
+        uri: service.uri || url.format(defaultRedisURI)
       }
     case 'mongodb':
       var defaultMongoURI = { protocol: 'mongodb', hostname: 'localhost', port: 27017, slashes: true }
-      if (service.credentials.host) defaultMongoURI.hostname = service.credentials.host
-      if (service.credentials.port) defaultMongoURI.port = service.credentials.port
-      if (service.credentials.password) defaultMongoURI.auth = `:${service.credentials.password}`
-      if (service.credentials.database) defaultMongoURI.pathname = service.credentials.database
+      if (service.host) defaultMongoURI.hostname = service.host
+      if (service.port) defaultMongoURI.port = service.port
+      if (service.password) defaultMongoURI.auth = `:${service.password}`
+      if (service.database) defaultMongoURI.pathname = service.database
       return {
-        uri: service.credentials.uri || url.format(defaultMongoURI)
+        uri: service.uri || url.format(defaultMongoURI)
       }
     case 'postgresql':
       var defaultPostgresURI = { protocol: 'postgres', hostname: 'localhost', port: 5432, slashes: true }
-      if (service.credentials.host) defaultPostgresURI.hostname = service.credentials.host
-      if (service.credentials.port) defaultPostgresURI.port = service.credentials.port
-      if (service.credentials.username || service.credentials.password) {
+      if (service.host) defaultPostgresURI.hostname = service.host
+      if (service.port) defaultPostgresURI.port = service.port
+      if (service.username || service.password) {
         defaultPostgresURI.auth = [
-          service.credentials.username,
-          service.credentials.password
+          service.username,
+          service.password
         ].join(':')
       }
-      if (service.credentials.database) defaultPostgresURI.pathname = service.credentials.database
+      if (service.database) defaultPostgresURI.pathname = service.database
       return {
-        uri: service.credentials.uri || url.format(defaultPostgresURI)
+        uri: service.uri || url.format(defaultPostgresURI)
       }
-    case 'objectstorage':
+    case 'objectStorage':
       var defaultAuthURL = 'https://identity.open.softlayer.com'
       return {
-        auth_url: service.credentials.auth_url || defaultAuthURL,
-        project: service.credentials.project || '',
-        projectId: service.credentials.projectId || '',
-        region: service.credentials.region || '',
-        userId: service.credentials.userId || '',
-        username: service.credentials.username || '',
-        password: service.credentials.password || '',
-        domainId: service.credentials.domainId || '',
-        domainName: service.credentials.domainName || '',
-        role: service.credentials.role || ''
+        auth_url: service.auth_url || defaultAuthURL,
+        project: service.project || '',
+        projectId: service.projectId || '',
+        region: service.region || '',
+        userId: service.userId || '',
+        username: service.username || '',
+        password: service.password || '',
+        domainId: service.domainId || '',
+        domainName: service.domainName || '',
+        role: service.role || ''
       }
-    case 'appid':
+    case 'auth':
       return {
-        clientId: service.credentials.clientId || '',
-        oauthServerUrl: service.credentials.oauthServerUrl || '',
-        profilesUrl: service.credentials.profilesUrl || '',
-        secret: service.credentials.secret || '',
-        tenantId: service.credentials.tenantId || ''
+        clientId: service.clientId || '',
+        oauthServerUrl: service.oauthServerUrl || '',
+        profilesUrl: service.profilesUrl || '',
+        secret: service.secret || '',
+        tenantId: service.tenantId || ''
       }
-    case 'watsonconversation':
+    case 'conversation':
       var defaultConversationURL = 'https://gateway.watsonplatform.net/conversation/api'
       return {
-        url: service.credentials.url || defaultConversationURL,
-        username: service.credentials.username || '',
-        password: service.credentials.password || ''
+        url: service.url || defaultConversationURL,
+        username: service.username || '',
+        password: service.password || ''
       }
-    case 'alertnotification':
+    case 'alertNotification':
       return {
-        url: service.credentials.url || '',
-        name: service.credentials.name || '',
-        password: service.credentials.password || ''
+        url: service.url || '',
+        name: service.name || '',
+        password: service.password || ''
       }
-    case 'pushnotifications':
+    case 'push':
       return {
-        appGuid: service.credentials.appGuid || '',
-        url: service.credentials.url || '',
-        admin_url: service.credentials.admin_url || '',
-        appSecret: service.credentials.appSecret || '',
-        clientSecret: service.credentials.clientSecret || ''
+        appGuid: service.appGuid || '',
+        url: service.url || '',
+        admin_url: service.admin_url || '',
+        appSecret: service.appSecret || '',
+        clientSecret: service.clientSecret || ''
       }
     case 'autoscaling':
       return {}
@@ -490,12 +490,15 @@ function sanitizeCredentialsAndFillInDefaults (serviceType, service) {
 };
 
 exports.sanitizeServiceAndFillInDefaults = function (serviceType, service) {
-  return {
-    name: service.name,
-    label: service.label || exports.getBluemixServiceLabel(serviceType),
-    plan: service.plan || exports.getBluemixDefaultPlan(serviceType),
-    credentials: sanitizeCredentialsAndFillInDefaults(serviceType, service)
+  var credentials = sanitizeCredentialsAndFillInDefaults(serviceType, service)
+  var serviceInfo = {
+    serviceInfo: {
+      name: service.serviceInfo.name,
+      label: service.serviceInfo.label || exports.getBluemixServiceLabel(serviceType),
+      plan: service.serviceInfo.plan || exports.getBluemixDefaultPlan(serviceType)
+    }
   }
+  return Object.assign(credentials, serviceInfo)
 }
 
 exports.getBluemixServiceLabel = function (serviceType) {
@@ -504,11 +507,11 @@ exports.getBluemixServiceLabel = function (serviceType) {
     case 'redis': return 'compose-for-redis'
     case 'mongodb': return 'compose-for-mongodb'
     case 'postgresql': return 'compose-for-postgresql'
-    case 'objectstorage': return 'Object-Storage'
-    case 'appid': return 'AppID'
-    case 'watsonconversation': return 'conversation'
-    case 'alertnotification': return 'AlertNotification'
-    case 'pushnotifications': return 'imfpush'
+    case 'objectStorage': return 'Object-Storage'
+    case 'auth': return 'AppID'
+    case 'conversation': return 'conversation'
+    case 'alertNotification': return 'AlertNotification'
+    case 'push': return 'imfpush'
     case 'autoscaling': return 'Auto-Scaling'
     default: return serviceType
   }
@@ -520,11 +523,11 @@ exports.getBluemixDefaultPlan = function (serviceType) {
     case 'redis': return 'Standard'
     case 'mongodb': return 'Standard'
     case 'postgresql': return 'Standard'
-    case 'objectstorage': return 'Free'
-    case 'appid': return 'Graduated tier'
-    case 'watsonconversation': return 'free'
-    case 'alertnotification': return 'authorizedusers'
-    case 'pushnotifications': return 'lite'
+    case 'objectStorage': return 'Free'
+    case 'auth': return 'Graduated tier'
+    case 'conversation': return 'free'
+    case 'alertNotification': return 'authorizedusers'
+    case 'push': return 'lite'
     case 'autoscaling': return 'free'
     default: return 'Lite'
   }
@@ -572,4 +575,20 @@ exports.resourceNameFromPath = function (thepath) {
   // grab the first valid element of a path (or partial path) and return it capitalized.
   var resource = thepath.match(/^\/*([^/]+)/)[1]
   return resource.charAt(0).toUpperCase() + resource.slice(1)
+}
+
+exports.isThisServiceAnArray = function (serviceType) {
+  if (serviceType === 'cloudant' || serviceType === 'objectStorage') {
+    return true
+  }
+  return false
+}
+
+exports.validateServiceFields = function (serviceType, service) {
+  if (!service.serviceInfo.name) {
+    throw new Error(chalk.red(`Service name is missing in spec for bluemix.${serviceType}`))
+  }
+  if (typeof (service.serviceInfo.name) !== 'string') {
+    throw new Error(chalk.red(`Ensure Type of Service name in spec for bluemix.${serviceType}`))
+  }
 }

--- a/refresh/templates/common/README.scaffold.md
+++ b/refresh/templates/common/README.scaffold.md
@@ -1,8 +1,6 @@
 ## Scaffolded Swift Kitura server application
 
-<% if (bluemix) { -%>
 [![](https://img.shields.io/badge/bluemix-powered-blue.svg)](https://bluemix.net)
-<% } -%>
 [![Platform](https://img.shields.io/badge/platform-swift-lightgrey.svg?style=flat)](https://developer.ibm.com/swift/)
 
 ### Table of Contents
@@ -11,9 +9,7 @@
 * [Project contents](#project-contents)
 * [Configuration](#configuration)
 * [Run](#run)
-<% if (bluemix) { -%>
 * [Deploy to Bluemix](#deploy-to-bluemix)
-<% } -%>
 * [License](#license)
 * [Generator](#generator)
 
@@ -26,11 +22,7 @@ This scaffolded application provides a starting point for creating Swift applica
 ### Project contents
 This application has been generated with the following capabilities and services:
 
-<% if (bluemix) { -%>
 * [CloudConfiguration](#configuration)
-<% } else { -%>
-* [Configuration](#configuration)
-<% } -%>
 <% if (web) { -%>
 * [Static web file serving](#static-web-file-serving)
 <% } -%>
@@ -46,39 +38,30 @@ This application has been generated with the following capabilities and services
 <% if (docker) { -%>
 * [Docker files](#docker-files)
 <% } -%>
-<% if (bluemix) { -%>
 * [Bluemix cloud deployment](#bluemix-cloud-deployment)
-<%   if (cloudant) { -%>
+<% if (cloudant) { -%>
 * [Cloudant](#cloudant)
-<%   } -%>
-<%   if (redis) { -%>
+<% } -%>
+<% if (redis) { -%>
 * [Redis](#redis)
-<%   } -%>
-<%   if (objectstorage) { -%>
+<% } -%>
+<% if (objectStorage) { -%>
 * [Object Storage](#object-storage)
-<%   } -%>
-<%   if (appid) { -%>
+<% } -%>
+<% if (auth) { -%>
 * [AppID](#appid)
-<%   } -%>
-<%   if (watsonconversation) { -%>
+<% } -%>
+<% if (conversation) { -%>
 * [Watson Conversation](#watson-conversation)
-<%   } -%>
-<%   if (alertnotification) { -%>
+<% } -%>
+<% if (alertNotification) { -%>
 * [Alert Notification](#alert-notification)
-<%   } -%>
-<%   if (pushnotifications) { -%>
+<% } -%>
+<% if (push) { -%>
 * [Push Notifications](#push-notifications)
-<%   } -%>
-<%   if (autoscaling) { -%>
+<% } -%>
+<% if (autoscaling) { -%>
 * [Auto-scaling](#auto-scaling)
-<%   } -%>
-<% } else { -%>
-<%   if (cloudant) { -%>
-* [CouchDB](#couchdb)
-<%   } -%>
-<%   if (redis) { -%>
-* [Redis](#redis)
-<%   } -%>
 <% } -%>
 
 <% if (web) { -%>
@@ -124,7 +107,6 @@ The `Dockerfile-tools` is a docker specification file similar to the `Dockerfile
 
 Details on how to build the docker images, compile and run the application within the docker image can be found in the [Run section](#run) below.
 <% } -%>
-<% if (bluemix) { -%>
 #### Bluemix cloud deployment
 Your application has a set of Bluemix cloud deployment configuration files defined to support deploying your application to Bluemix:
 * `manifest.yml`
@@ -135,7 +117,7 @@ The [`manifest.yml`](https://console.ng.bluemix.net/docs/manageapps/depapps.html
 
 [IBM Bluemix DevOps](https://console.ng.bluemix.net/docs/services/ContinuousDelivery/index.html) service provides toolchains as a set of tool integrations that support development, deployment, and operations tasks inside Bluemix. The ["Create Toolchain"](#deploy-to-bluemix) button creates a DevOps toolchain and acts as a single-click deploy to Bluemix including provisioning all required services.
 
-<%   if (cloudant) { -%>
+<% if (cloudant) { -%>
 #### Cloudant
 This application uses the [Kitura-CouchDB package](https://github.com/IBM-Swift/Kitura-CouchDB), which allows Kitura applications to interact with a Cloudant or CouchDB database.
 
@@ -144,8 +126,8 @@ CouchDB speaks JSON natively and supports binary for all your data storage needs
 Boilerplate code for creating a client object for the Kitura-CouchDB API is included inside `Sources/Application/Application.swift` as an `internal` variable available for use anywhere in the `Application` module.
 
 The connection details for this client are loaded by the [configuration](#configuration) code and are passed to the Kitura-CouchDB client in the boilerplate code.
-<%   } -%>
-<%   if (redis) { -%>
+<% } -%>
+<% if (redis) { -%>
 #### Redis
 This application uses the [Kitura-redis](http://ibm-swift.github.io/Kitura-redis/) library, which allows Kitura applications to interact with a Redis database.
 
@@ -154,8 +136,8 @@ Redis is an open source (BSD licensed), in-memory data structure store, used as 
 Boilerplate code for creating a client object for the Kitura-redis API is included inside `Sources/Application/Application.swift` as an `internal` variable available for use anywhere in the `Application` module.
 
 The connection details for this client are loaded by  the [configuration](#configuration) code and are passed to the Kitura-redis client in the boilerplate code.
-<%   } -%>
-<%   if (objectstorage) { -%>
+<% } -%>
+<% if (objectStorage) { -%>
 #### Object Storage
 This application uses the [Object Storage package](https://github.com/ibm-bluemix-mobile-services/bluemix-objectstorage-serversdk-swift.git) to connect to the Bluemix Object Storage service.
 
@@ -164,8 +146,8 @@ Object Storage provides an unstructured cloud data store, which allows the appli
 Boilerplate code for creating a client object for the Object Storage API is included inside `Sources/Application/Application.swift` as an `internal` variable available for use anywhere in the `Application` module.
 
 The connection details for this client are loaded by the [configuration](#configuration) code and are passed to the Object Storage client in the boilerplate code.
-<%   } -%>
-<%   if (appid) { -%>
+<% } -%>
+<% if (auth) { -%>
 #### AppID
 This application uses [App ID package](https://github.com/ibm-cloud-security/appid-serversdk-swift) to connect to the Bluemix App ID service.
 
@@ -174,8 +156,8 @@ App ID provides authentication to secure your web applications and back-end syst
 Boilerplate code for creating a client object for the App ID API is included inside `Sources/Application/Application.swift` as an `internal` variable available for use anywhere in the `Application` module. Extra routes and logic need to be added to make this a authentication boilerplate work. A working example can be found in the [App ID README](https://github.com/ibm-cloud-security/appid-serversdk-swift/blob/master/README.md#example-usage).
 
 The connection details for this client are loaded by the [configuration](#configuration) code and are passed to the App ID client in the boilerplate code.
-<%   } -%>
-<%   if (watsonconversation) { -%>
+<% } -%>
+<% if (conversation) { -%>
 #### Watson Conversation
 This application uses the [Watson Swift SDK package](https://github.com/watson-developer-cloud/swift-sdk), which allows Kitura applications to build Watson-powered applications, specifically in this case the IBM Watson Conversation service.
 
@@ -186,8 +168,8 @@ Boilerplate code for creating a client object for the Watson Conversation API is
 The connection details for this client are loaded by the [configuration](#configuration) code and are passed to the Watson Conversation client in the boilerplate code.
 
 More information about the Watson Conversation can be found in the [README](https://github.com/watson-developer-cloud/swift-sdk#conversation).
-<%   } -%>
-<%   if (alertnotification) { -%>
+<% } -%>
+<% if (alertNotification) { -%>
 #### Alert Notification
 This application uses the [Alert Notification Service SDK package](https://github.com/IBM-Swift/alert-notification-sdk), which allows Swift developers to utilize the Alert Notifications Bluemix service in their applications, allowing for the proactive remediation of issues for applications running on the Bluemix cloud. Alerts and messages can be created, received and deleted through the use of this SDK.
 
@@ -198,42 +180,20 @@ Boilerplate code for creating a client object for the Alert Notification API is 
 The connection details for this client are loaded by the [configuration](#configuration) code and are passed to the Alert Notification client in the boilerplate code.
 
 A quick start guide to the IBM Alert Notification Service on Bluemix can be found  [here](https://www.ibm.com/blogs/bluemix/2015/12/quick-start-guide-to-alert-notification-service/).
-<%   } -%>
-<%   if (pushnotifications) { -%>
+<% } -%>
+<% if (push) { -%>
 #### Push Notifications
 This application uses the [Bluemix Push notifications package](https://github.com/ibm-bluemix-mobile-services/bms-pushnotifications-serversdk-swift), which is a Swift server-side SDK for sending push notifications via the Bluemix Push Notifications services.
 
 Boilerplate code for creating a client object for the Push Notifications API is included inside `Sources/Application/Application.swift` as an `internal` variable available for use anywhere in the `Application` module.
 
 The connection details for this client are loaded by the [configuration](#configuration) code and are passed to the Push Notifications client in the boilerplate code.
-<%   } -%>
-<%   if (autoscaling) { -%>
+<% } -%>
+<% if (autoscaling) { -%>
 #### Auto-scaling
 This application uses the [SwiftMetrics package](https://github.com/RuntimeTools/SwiftMetrics) for connecting to the Bluemix Auto-scaling service. You can use this to automatically manage your application capacity when deployed to Bluemix.  You will need to define the Auto-Scaling policy (https://console.ng.bluemix.net/docs/services/Auto-Scaling/index.html) to define the rules used to scale the application.
 
 The connection details for this client are loaded by the [configuration](#configuration) code and are passed to the SwiftMetrics auto-scaling client in the boilerplate code.
-<%   } -%>
-<% } else { -%>
-<%   if (cloudant) { -%>
-#### CouchDB
-This application uses the [Kitura-CouchDB package](https://github.com/IBM-Swift/Kitura-CouchDB), which allows Kitura applications to interact with a CouchDB database.
-
-CouchDB speaks JSON natively and supports binary for all your data storage needs.
-
-Boilerplate code for creating a client object for the Kitura-CouchDB API is included inside `Sources/Application/Application.swift` as an `internal` variable available for use anywhere in the `Application` module.
-
-The connection details for this client are loaded by the [configuration](#configuration) code and are passed to the Kitura-CouchDB client in the boilerplate code.
-<%   } -%>
-<%   if (redis) { -%>
-#### Redis
-This application uses the [Kitura-redis](http://ibm-swift.github.io/Kitura-redis/) library, which allows Kitura applications to interact with a Redis database.
-
-Redis is an open source (BSD licensed), in-memory data structure store, used as a database, cache and message broker. It supports a cracking array of data structures such as strings, hashes, lists, sets, sorted sets with range queries, bitmaps, hyperloglogs and geospatial indexes with radius queries.
-
-Boilerplate code for creating a client object for the Kitura-redis API is included inside `Sources/Application/Application.swift` as an `internal` variable available for use anywhere in the `Application` module.
-
- The connection details for this client are loaded by the [configuration](#configuration) code and stored in a `struct` for easy access when creating connections to Redis.
-<%   } -%>
 <% } -%>
 
 ### Configuration
@@ -241,15 +201,11 @@ Your application configuration information is stored in the `config.json` in the
 
 The connection information for any configured services, such as username, password and hostname, is stored in this file.
 
-<% if (bluemix) { -%>
 The application uses the [CloudConfiguration package](https://github.com/IBM-Swift/CloudConfiguration) to read the connection and configuration information from the environment and this file.
 
 If the application is running locally, it can connect to Bluemix services using unbound credentials read from this file. If you need to create unbound credentials you can do so from the Bluemix web console ([example](https://console.ng.bluemix.net/docs/services/Cloudant/tutorials/create_service.html#creating-a-service-instance)), or using the CloudFoundry CLI [`cf create-service-key` command](http://cli.cloudfoundry.org/en-US/cf/create-service-key.html).
 
 When you push your application to Bluemix, these values are no longer used, instead Bluemix automatically connects to bound services using environment variables.
-<% } else {-%>
-The application uses the [Configuration package](https://github.com/IBM-Swift/Configuration) to read the connection and configuration information from this file.
-<% } -%>
 
 ### Run
 To build and run the application:
@@ -274,7 +230,6 @@ To run the application:
 * `docker run -it -p 8080:8080 -v $PWD:/root/project -w /root/project myapp-run sh -c .build-ubuntu/release/<%- executableName %>`
 <% } -%>
 
-<% if (bluemix) { -%>
 ### Deploy to Bluemix
 You can deploy your application to Bluemix using:
 * the [CloudFoundry CLI](#cloudfoundry-cli)
@@ -292,7 +247,6 @@ The Cloud Foundry CLI will not provision the configured services for you, so you
 You can also set up a default Bluemix Toolchain to handle deploying your application to Bluemix. This is achieved by publishing your application to a publicly accessible github repository and using the "Create Toolchain" button below. In this case configured services will be automatically provisioned, once, during toolchain creation.
 
 [![Create Toolchain](https://console.ng.bluemix.net/devops/graphics/create_toolchain_button.png)](https://console.ng.bluemix.net/devops/setup/deploy/)
-<% } -%>
 
 ### License
 All generated content is available for use and modification under the permissive MIT License (see `LICENSE` file), with the exception of SwaggerUI which is licensed under an Apache-2.0 license (see `NOTICES.txt` file).

--- a/test/integration/app/spec_build.js
+++ b/test/integration/app/spec_build.js
@@ -100,9 +100,9 @@ describe('Integration tests (spec build) for swiftserver:app', function () {
                                 docker: true,
                                 metrics: true,
                                 // serverSwaggerFiles: [ serverSDKFile ],
-                                services: {
-                                  cloudant: [{ name: 'myCloudantService' }],
-                                  autoscaling: [{ name: 'myAutoscalingService' }]
+                                bluemix: {
+                                  cloudant: [{ serviceInfo: { name: 'myCloudantService' } }],
+                                  autoscaling: { serviceInfo: { name: 'myAutoscalingService' } }
                                 },
                                 crudservice: 'myCloudantService'
                               })

--- a/test/lib/common_test.js
+++ b/test/lib/common_test.js
@@ -581,7 +581,7 @@ exports.appid = {
     var description = 'appid'
     var mapping = 'appid'
     var label = 'AppID'
-    var plan = servicePlan || helpers.getBluemixDefaultPlan('appid')
+    var plan = servicePlan || helpers.getBluemixDefaultPlan('auth')
     var sourceFile = 'ServiceAppid.swift'
     var initFunction = 'initializeServiceAppid'
 
@@ -609,7 +609,7 @@ exports.watsonconversation = {
     var description = 'watson conversation'
     var mapping = 'watson_conversation'
     var label = 'conversation'
-    var plan = servicePlan || helpers.getBluemixDefaultPlan('watsonconversation')
+    var plan = servicePlan || helpers.getBluemixDefaultPlan('conversation')
     var sourceFile = 'ServiceWatsonConversation.swift'
     var initFunction = 'initializeServiceWatsonConversation'
 
@@ -636,7 +636,7 @@ exports.pushnotifications = {
     var description = 'push notifications'
     var mapping = 'push'
     var label = 'imfpush'
-    var plan = servicePlan || helpers.getBluemixDefaultPlan('pushnotifications')
+    var plan = servicePlan || helpers.getBluemixDefaultPlan('push')
     var sourceFile = 'ServicePush.swift'
     var initFunction = 'initializeServicePush'
 
@@ -663,7 +663,7 @@ exports.alertnotification = {
     var description = 'alert notification'
     var mapping = 'alert_notification'
     var label = 'AlertNotification'
-    var plan = servicePlan || helpers.getBluemixDefaultPlan('alertnotification')
+    var plan = servicePlan || helpers.getBluemixDefaultPlan('alertNotification')
     var sourceFile = 'ServiceAlertNotification.swift'
     var initFunction = 'initializeServiceAlertNotification'
 
@@ -690,7 +690,7 @@ exports.objectstorage = {
     var description = 'object storage'
     var mapping = 'object_storage'
     var label = 'Object-Storage'
-    var plan = servicePlan || helpers.getBluemixDefaultPlan('objectstorage')
+    var plan = servicePlan || helpers.getBluemixDefaultPlan('objectStorage')
     var sourceFile = 'ServiceObjectStorage.swift'
     var initFunction = 'initializeServiceObjectStorage'
 
@@ -754,7 +754,7 @@ exports.mongodb = {
     exports.itHasServiceInBluemixPipeline(description, label, plan, serviceName)
     exports.itCreatedServiceBoilerplate(description, sourceFile, initFunction)
 
-    it('redis boilerplate contains expected content', function () {
+    it('mongodb boilerplate contains expected content', function () {
       var serviceFile = `${exports.servicesSourceDir}/${sourceFile}`
       assert.fileContent([
         [serviceFile, 'import MongoKitten'],

--- a/test/unit/app.js
+++ b/test/unit/app.js
@@ -36,6 +36,7 @@ function itCreatedSpecWithServicesAndCapabilities (optsGenerator) {
     var appType = opts.appType
     var appName = opts.appName
     var capabilities = opts.capabilities
+    var bluemix = opts.bluemix
     var services = opts.services
     var crudservice = opts.crudservice
     var fromSwagger = opts.fromSwagger
@@ -43,11 +44,10 @@ function itCreatedSpecWithServicesAndCapabilities (optsGenerator) {
     function hasCapability (name) {
       return (capabilities.indexOf(name) !== -1)
     }
-
     var spec = runContext.generator.spec
     var expectedSpec = {
-      appName: appName,
       appType: appType,
+      appName: appName,
       docker: hasCapability('docker') || undefined,
       metrics: hasCapability('metrics') || undefined,
       web: hasCapability('web') || undefined,
@@ -56,19 +56,12 @@ function itCreatedSpecWithServicesAndCapabilities (optsGenerator) {
       swaggerUI: hasCapability('swaggerUI') || undefined,
       fromSwagger: fromSwagger || undefined,
       serverSwaggerFiles: undefined,
-      services: {},
+      bluemix: bluemix || {},
       crudservice: crudservice || undefined
     }
     // deal with services
     Object.keys(services).forEach(serviceType => {
-      var expectedService = { credentials: {} }
-      if (services[serviceType].name) {
-        expectedService.name = services[serviceType].name
-      }
-      if (services[serviceType].credentials) {
-        expectedService.credentials = services[serviceType].credentials
-      }
-      expectedSpec.services[serviceType] = [expectedService]
+      expectedSpec.bluemix[serviceType] = services[serviceType]
     })
     assert.objectContent(spec, expectedSpec)
 
@@ -1040,14 +1033,14 @@ describe('Unit tests for swiftserver:app', function () {
             appName: applicationName,
             capabilities: [],
             services: {
-              'cloudant': {
-                name: 'myCloudantService',
-                credentials: {
-                  host: 'cloudanthost',
-                  port: 4568,
-                  secured: true
-                }
-              }
+              'cloudant': [{
+                serviceInfo: {
+                  name: 'myCloudantService'
+                },
+                host: 'cloudanthost',
+                port: 4568,
+                secured: true
+              }]
             }
           }))
         })
@@ -1085,16 +1078,16 @@ describe('Unit tests for swiftserver:app', function () {
             appName: applicationName,
             capabilities: [],
             services: {
-              cloudant: {
-                name: 'myCloudantService',
-                credentials: {
-                  host: 'cloudanthost',
-                  port: 4568,
-                  secured: true,
-                  username: 'admin',
-                  password: 'password123'
-                }
-              }
+              cloudant: [{
+                serviceInfo: {
+                  name: 'myCloudantService'
+                },
+                host: 'cloudanthost',
+                port: 4568,
+                secured: true,
+                username: 'admin',
+                password: 'password123'
+              }]
             }
           }))
         })
@@ -1163,12 +1156,12 @@ describe('Unit tests for swiftserver:app', function () {
           capabilities: [],
           services: {
             redis: {
-              name: 'myRedisService',
-              credentials: {
-                host: 'myhost',
-                port: 1234,
-                password: 'password1234'
-              }
+              serviceInfo: {
+                name: 'myRedisService'
+              },
+              host: 'myhost',
+              port: 1234,
+              password: 'password1234'
             }
           }
         }))
@@ -1238,13 +1231,13 @@ describe('Unit tests for swiftserver:app', function () {
           capabilities: [],
           services: {
             mongodb: {
-              name: 'myMongoService',
-              credentials: {
-                host: 'myhost',
-                port: 1234,
-                password: 'password1234',
-                database: 'mydb'
-              }
+              serviceInfo: {
+                name: 'myMongoService'
+              },
+              host: 'myhost',
+              port: 1234,
+              password: 'password1234',
+              database: 'mydb'
             }
           }
         }))
@@ -1277,7 +1270,7 @@ describe('Unit tests for swiftserver:app', function () {
           appType: 'scaffold',
           appName: applicationName,
           capabilities: [],
-          services: { objectstorage: {} }
+          services: { objectStorage: {} }
         }))
       })
 
@@ -1313,15 +1306,15 @@ describe('Unit tests for swiftserver:app', function () {
           appName: applicationName,
           capabilities: [],
           services: {
-            objectstorage: {
-              name: 'myObjectStorageService',
-              credentials: {
-                region: 'dallas',
-                projectId: 'myProjectId',
-                userId: 'admin',
-                password: 'password1234'
-              }
-            }
+            objectStorage: [{
+              serviceInfo: {
+                name: 'myObjectStorageService'
+              },
+              region: 'dallas',
+              projectId: 'myProjectId',
+              userId: 'admin',
+              password: 'password1234'
+            }]
           }
         }))
       })
@@ -1353,7 +1346,7 @@ describe('Unit tests for swiftserver:app', function () {
           appType: 'scaffold',
           appName: applicationName,
           capabilities: [],
-          services: { appid: {} }
+          services: { auth: {} }
         }))
       })
 
@@ -1388,13 +1381,13 @@ describe('Unit tests for swiftserver:app', function () {
           appName: applicationName,
           capabilities: [],
           services: {
-            appid: {
-              name: 'myAppIDService',
-              credentials: {
-                tenantId: 'myTenantId',
-                clientId: 'myClientId',
-                secret: 'mySecret'
-              }
+            auth: {
+              serviceInfo: {
+                name: 'myAppIDService'
+              },
+              tenantId: 'myTenantId',
+              clientId: 'myClientId',
+              secret: 'mySecret'
             }
           }
         }))
@@ -1427,7 +1420,7 @@ describe('Unit tests for swiftserver:app', function () {
           appType: 'scaffold',
           appName: applicationName,
           capabilities: [],
-          services: { watsonconversation: {} }
+          services: { conversation: {} }
         }))
       })
 
@@ -1462,13 +1455,13 @@ describe('Unit tests for swiftserver:app', function () {
           appName: applicationName,
           capabilities: [],
           services: {
-            watsonconversation: {
-              name: 'myConversationService',
-              credentials: {
-                username: 'admin',
-                password: 'password1234',
-                url: 'https://myhost'
-              }
+            conversation: {
+              serviceInfo: {
+                name: 'myConversationService'
+              },
+              username: 'admin',
+              password: 'password1234',
+              url: 'https://myhost'
             }
           }
         }))
@@ -1501,7 +1494,7 @@ describe('Unit tests for swiftserver:app', function () {
           appType: 'scaffold',
           appName: applicationName,
           capabilities: [],
-          services: { alertnotification: {} }
+          services: { alertNotification: {} }
         }))
       })
 
@@ -1536,13 +1529,13 @@ describe('Unit tests for swiftserver:app', function () {
           appName: applicationName,
           capabilities: [],
           services: {
-            alertnotification: {
-              name: 'myAlertNotificationService',
-              credentials: {
-                name: 'admin',
-                password: 'password1234',
-                url: 'https://myhost'
-              }
+            alertNotification: {
+              serviceInfo: {
+                name: 'myAlertNotificationService'
+              },
+              name: 'admin',
+              password: 'password1234',
+              url: 'https://myhost'
             }
           }
         }))
@@ -1575,7 +1568,7 @@ describe('Unit tests for swiftserver:app', function () {
           appType: 'scaffold',
           appName: applicationName,
           capabilities: [],
-          services: { pushnotifications: {} }
+          services: { push: { serviceInfo: { label: 'imfpush' } } }
         }))
       })
 
@@ -1610,14 +1603,14 @@ describe('Unit tests for swiftserver:app', function () {
             appType: 'scaffold',
             appName: applicationName,
             capabilities: [],
+            bluemix: { server: { domain: 'ng.bluemix.net' } },
             services: {
-              pushnotifications: {
-                name: 'myPushNotificationsService',
-                region: 'US_SOUTH',
-                credentials: {
-                  appGuid: 'myAppGuid',
-                  appSecret: 'myAppSecret'
-                }
+              push: {
+                serviceInfo: {
+                  name: 'myPushNotificationsService'
+                },
+                appGuid: 'myAppGuid',
+                appSecret: 'myAppSecret'
               }
             }
           }))
@@ -1681,7 +1674,7 @@ describe('Unit tests for swiftserver:app', function () {
         appType: 'scaffold',
         appName: applicationName,
         capabilities: [],
-        services: { autoscaling: {} }
+        services: { autoscaling: { serviceInfo: { label: 'Auto-Scaling' } } }
       }))
     })
   })
@@ -1804,7 +1797,7 @@ describe('Unit tests for swiftserver:app', function () {
         appType: 'crud',
         appName: applicationName,
         capabilities: [],
-        services: { autoscaling: {} }
+        services: { autoscaling: { serviceInfo: { label: 'Auto-Scaling' } } }
       }))
     })
 
@@ -1834,7 +1827,7 @@ describe('Unit tests for swiftserver:app', function () {
           appType: 'crud',
           appName: applicationName,
           capabilities: [],
-          services: { cloudant: { name: 'crudDataStore' } },
+          services: { cloudant: [{ serviceInfo: { name: 'crudDataStore' } }] },
           crudservice: 'crudDataStore'
         }))
       })
@@ -1870,14 +1863,14 @@ describe('Unit tests for swiftserver:app', function () {
             appName: applicationName,
             capabilities: [],
             services: {
-              'cloudant': {
-                name: 'crudDataStore',
-                credentials: {
-                  host: 'cloudanthost',
-                  port: 4568,
-                  secured: true
-                }
-              }
+              'cloudant': [{
+                serviceInfo: {
+                  name: 'crudDataStore'
+                },
+                host: 'cloudanthost',
+                port: 4568,
+                secured: true
+              }]
             },
             crudservice: 'crudDataStore'
           }))
@@ -1915,16 +1908,16 @@ describe('Unit tests for swiftserver:app', function () {
             appName: applicationName,
             capabilities: [],
             services: {
-              'cloudant': {
-                name: 'crudDataStore',
-                credentials: {
-                  host: 'cloudanthost',
-                  port: 4568,
-                  secured: true,
-                  username: 'admin',
-                  password: 'password123'
-                }
-              }
+              'cloudant': [{
+                serviceInfo: {
+                  name: 'crudDataStore'
+                },
+                host: 'cloudanthost',
+                port: 4568,
+                secured: true,
+                username: 'admin',
+                password: 'password123'
+              }]
             },
             crudservice: 'crudDataStore'
           }))

--- a/test/unit/app.js
+++ b/test/unit/app.js
@@ -1270,7 +1270,7 @@ describe('Unit tests for swiftserver:app', function () {
           appType: 'scaffold',
           appName: applicationName,
           capabilities: [],
-          services: { objectStorage: {} }
+          services: { objectStorage: [{ serviceInfo: {label: 'Object-Storage'} }] }
         }))
       })
 
@@ -1420,7 +1420,7 @@ describe('Unit tests for swiftserver:app', function () {
           appType: 'scaffold',
           appName: applicationName,
           capabilities: [],
-          services: { conversation: {} }
+          services: { conversation: { serviceInfo: {label: 'conversation'} } }
         }))
       })
 
@@ -1494,7 +1494,7 @@ describe('Unit tests for swiftserver:app', function () {
           appType: 'scaffold',
           appName: applicationName,
           capabilities: [],
-          services: { alertNotification: {} }
+          services: { alertNotification: { serviceInfo: {label: 'AlertNotification'} } }
         }))
       })
 

--- a/test/unit/helpers.js
+++ b/test/unit/helpers.js
@@ -78,92 +78,92 @@ describe('Unit tests for helpers', function () {
     describe('default values', function () {
       var expectedDefaultValues = {
         cloudant: {
-          label: 'cloudantNoSQLDB',
-          plan: 'Lite',
-          credentials: {
-            url: 'http://localhost:5984',
-            host: 'localhost',
-            username: '',
-            password: '',
-            secured: false,
-            port: 5984
-          }
+          serviceInfo: {
+            label: 'cloudantNoSQLDB',
+            plan: 'Lite'
+          },
+          url: 'http://localhost:5984',
+          host: 'localhost',
+          username: '',
+          password: '',
+          secured: false,
+          port: 5984
         },
         redis: {
-          label: 'compose-for-redis',
-          plan: 'Standard',
-          credentials: {
-            uri: 'redis://:@localhost:6397'
-          }
+          serviceInfo: {
+            label: 'compose-for-redis',
+            plan: 'Standard'
+          },
+          uri: 'redis://:@localhost:6397'
         },
-        objectstorage: {
-          label: 'Object-Storage',
-          plan: 'Free',
-          credentials: {
-            auth_url: 'https://identity.open.softlayer.com',
-            project: '',
-            projectId: '',
-            region: '',
-            userId: '',
-            username: '',
-            password: '',
-            domainId: '',
-            domainName: '',
-            role: ''
-          }
+        objectStorage: {
+          serviceInfo: {
+            label: 'Object-Storage',
+            plan: 'Free'
+          },
+          auth_url: 'https://identity.open.softlayer.com',
+          project: '',
+          projectId: '',
+          region: '',
+          userId: '',
+          username: '',
+          password: '',
+          domainId: '',
+          domainName: '',
+          role: ''
         },
-        appid: {
-          label: 'AppID',
-          plan: 'Graduated tier',
-          credentials: {
-            clientId: '',
-            oauthServerUrl: '',
-            profilesUrl: '',
-            secret: '',
-            tenantId: ''
-          }
+        auth: {
+          serviceInfo: {
+            label: 'AppID',
+            plan: 'Graduated tier'
+          },
+          clientId: '',
+          oauthServerUrl: '',
+          profilesUrl: '',
+          secret: ''
         },
-        watsonconversation: {
-          label: 'conversation',
-          plan: 'free',
-          credentials: {
-            url: 'https://gateway.watsonplatform.net/conversation/api',
-            username: '',
-            password: ''
-          }
+        conversation: {
+          serviceInfo: {
+            label: 'conversation',
+            plan: 'free'
+          },
+          url: 'https://gateway.watsonplatform.net/conversation/api',
+          username: '',
+          password: ''
         },
-        alertnotification: {
-          label: 'AlertNotification',
-          plan: 'authorizedusers',
-          credentials: {
-            url: '',
-            name: '',
-            password: ''
-          }
+        alertNotification: {
+          serviceInfo: {
+            label: 'AlertNotification',
+            plan: 'authorizedusers'
+          },
+          url: '',
+          name: '',
+          password: ''
         },
-        pushnotifications: {
-          label: 'imfpush',
-          plan: 'lite',
-          credentials: {
-            appGuid: '',
-            url: '',
-            admin_url: '',
-            appSecret: '',
-            clientSecret: ''
-          }
+        push: {
+          serviceInfo: {
+            label: 'imfpush',
+            plan: 'lite'
+          },
+          appGuid: '',
+          url: '',
+          admin_url: '',
+          appSecret: '',
+          clientSecret: ''
         },
         autoscaling: {
-          label: 'Auto-Scaling',
-          plan: 'free',
-          credentials: {}
+          serviceInfo: {
+            label: 'Auto-Scaling',
+            plan: 'free'
+          }
         }
       }
       Object.keys(expectedDefaultValues).forEach(serviceType => {
         it(`for ${serviceType}`, function () {
           var service = helpers.sanitizeServiceAndFillInDefaults(
-            serviceType, { name: 'myService', credentials: {} }
+            serviceType, { serviceInfo: {name: 'myService'} }
           )
-          assert.equal(service.name, 'myService')
+          assert.equal(service.serviceInfo.name, 'myService')
           assert.objectContent(service, expectedDefaultValues[serviceType])
         })
       })
@@ -182,7 +182,7 @@ describe('Unit tests for helpers', function () {
         redis: {
           uri: 'redis://:my-password@my-host:5555'
         },
-        objectstorage: {
+        objectStorage: {
           auth_url: 'http://my-auth-host',
           project: 'my-project',
           projectId: 'my-project-id',
@@ -194,24 +194,24 @@ describe('Unit tests for helpers', function () {
           domainName: 'my-domain-name',
           role: 'my-role'
         },
-        appid: {
+        auth: {
           clientId: 'my-client-id',
           oauthServerUrl: 'http://my-oauth-server-host',
           profilesUrl: 'http://my-profiles-host',
           secret: 'my-secret',
           tenantId: 'my-tenant-id'
         },
-        watsonconversation: {
+        conversation: {
           url: 'http://my-host',
           username: 'my-username',
           password: 'my-password'
         },
-        alertnotification: {
+        alertNotification: {
           url: 'http://my-host',
           name: 'my-name',
           password: 'my-password'
         },
-        pushnotifications: {
+        push: {
           appGuid: 'my-app-guid',
           url: 'http://my-host',
           admin_url: 'http://my-admin-host',
@@ -223,13 +223,14 @@ describe('Unit tests for helpers', function () {
       }
       Object.keys(specifiedCredentials).forEach(serviceType => {
         it(`for ${serviceType}`, function () {
+          var serviceInfo = { serviceInfo: {name: 'my-service', label: 'my-label', plan: 'my-plan'} }
           var service = helpers.sanitizeServiceAndFillInDefaults(
-            serviceType, { name: 'my-service', label: 'my-label', plan: 'my-plan', credentials: specifiedCredentials[serviceType] }
+            serviceType, Object.assign(specifiedCredentials[serviceType], serviceInfo)
           )
-          assert.equal(service.name, 'my-service')
-          assert.equal(service.label, 'my-label')
-          assert.equal(service.plan, 'my-plan')
-          assert.objectContent(service.credentials, specifiedCredentials[serviceType])
+          assert.equal(service.serviceInfo.name, 'my-service')
+          assert.equal(service.serviceInfo.label, 'my-label')
+          assert.equal(service.serviceInfo.plan, 'my-plan')
+          assert.objectContent(service, specifiedCredentials[serviceType])
         })
       })
     })
@@ -239,9 +240,9 @@ describe('Unit tests for helpers', function () {
         it('host, username, password, secured, port from url (merge with default)', function () {
           var specifiedCredentials = { url: 'http://my-username:my-password@my-host:4444' }
           var service = helpers.sanitizeServiceAndFillInDefaults(
-            'cloudant', { name: 'my-service', credentials: specifiedCredentials }
+            'cloudant', Object.assign(specifiedCredentials, { serviceInfo: {name: 'my-service'} })
           )
-          assert.objectContent(service.credentials, {
+          assert.objectContent(service, {
             url: specifiedCredentials.url,
             host: 'my-host',
             username: 'my-username',
@@ -259,9 +260,9 @@ describe('Unit tests for helpers', function () {
             port: 3333
           }
           var service = helpers.sanitizeServiceAndFillInDefaults(
-            'cloudant', { name: 'my-service', credentials: specifiedCredentials }
+            'cloudant', Object.assign(specifiedCredentials, { serviceInfo: {name: 'my-service'} })
           )
-          assert.objectContent(service.credentials, {
+          assert.objectContent(service, {
             url: 'http://my-username:my-password@my-host:3333',
             host: specifiedCredentials.host,
             username: specifiedCredentials.username,
@@ -274,9 +275,9 @@ describe('Unit tests for helpers', function () {
         it('url from host (merge with default)', function () {
           var specifiedCredentials = { host: 'my-host' }
           var service = helpers.sanitizeServiceAndFillInDefaults(
-            'cloudant', { name: 'my-service', credentials: specifiedCredentials }
+            'cloudant', Object.assign(specifiedCredentials, { serviceInfo: {name: 'my-service'} })
           )
-          assert.objectContent(service.credentials, {
+          assert.objectContent(service, {
             url: 'http://my-host:5984',
             host: specifiedCredentials.host,
             username: '',
@@ -289,9 +290,9 @@ describe('Unit tests for helpers', function () {
         it('url from port (merge with default)', function () {
           var specifiedCredentials = { port: 1111 }
           var service = helpers.sanitizeServiceAndFillInDefaults(
-            'cloudant', { name: 'my-service', credentials: specifiedCredentials }
+            'cloudant', Object.assign(specifiedCredentials, { serviceInfo: {name: 'my-service'} })
           )
-          assert.objectContent(service.credentials, {
+          assert.objectContent(service, {
             url: 'http://localhost:1111',
             host: 'localhost',
             username: '',
@@ -304,9 +305,9 @@ describe('Unit tests for helpers', function () {
         it('url from username, password (merge with default)', function () {
           var specifiedCredentials = { username: 'my-username', password: 'my-password' }
           var service = helpers.sanitizeServiceAndFillInDefaults(
-            'cloudant', { name: 'my-service', credentials: specifiedCredentials }
+            'cloudant', Object.assign(specifiedCredentials, { serviceInfo: {name: 'my-service'} })
           )
-          assert.objectContent(service.credentials, {
+          assert.objectContent(service, {
             url: 'http://my-username:my-password@localhost:5984',
             host: 'localhost',
             username: specifiedCredentials.username,
@@ -320,37 +321,37 @@ describe('Unit tests for helpers', function () {
       describe('for redis', function () {
         it('uri from host, port and password (no merge)', function () {
           var service = helpers.sanitizeServiceAndFillInDefaults(
-            'redis', { name: 'my-service', credentials: { password: 'my-password', host: 'my-host', port: 5555 } }
+            'redis', { serviceInfo: {name: 'my-service'}, password: 'my-password', host: 'my-host', port: 5555 }
           )
-          assert.equal(service.credentials.uri, 'redis://:my-password@my-host:5555')
+          assert.equal(service.uri, 'redis://:my-password@my-host:5555')
         })
 
         it('uri from password (merge with default)', function () {
           var service = helpers.sanitizeServiceAndFillInDefaults(
-            'redis', { name: 'my-service', credentials: { password: 'my-password' } }
+            'redis', { serviceInfo: {name: 'my-service'}, password: 'my-password' }
           )
-          assert.equal(service.credentials.uri, 'redis://:my-password@localhost:6397')
+          assert.equal(service.uri, 'redis://:my-password@localhost:6397')
         })
 
         it('uri from host (merge with default)', function () {
           var service = helpers.sanitizeServiceAndFillInDefaults(
-            'redis', { name: 'my-service', credentials: { host: 'my-host' } }
+            'redis', { serviceInfo: {name: 'my-service'}, host: 'my-host' }
           )
-          assert.equal(service.credentials.uri, 'redis://:@my-host:6397')
+          assert.equal(service.uri, 'redis://:@my-host:6397')
         })
 
         it('uri from port (merge with default)', function () {
           var service = helpers.sanitizeServiceAndFillInDefaults(
-            'redis', { name: 'my-service', credentials: { port: 5555 } }
+            'redis', { serviceInfo: {name: 'my-service'}, port: 5555 }
           )
-          assert.equal(service.credentials.uri, 'redis://:@localhost:5555')
+          assert.equal(service.uri, 'redis://:@localhost:5555')
         })
 
         it('uri and host, port and password (no merge)', function () {
           var service = helpers.sanitizeServiceAndFillInDefaults(
-            'redis', { name: 'my-service', credentials: { uri: 'redis://my-specific-host:1111', password: 'my-password', host: 'my-host', port: 5555 } }
+            'redis', { serviceInfo: {name: 'my-service'}, uri: 'redis://my-specific-host:1111', password: 'my-password', host: 'my-host', port: 5555 }
           )
-          assert.equal(service.credentials.uri, 'redis://my-specific-host:1111')
+          assert.equal(service.uri, 'redis://my-specific-host:1111')
         })
       })
     })
@@ -366,23 +367,23 @@ describe('Unit tests for helpers', function () {
     })
 
     it('get label for objectstorage', function () {
-      assert.equal(helpers.getBluemixServiceLabel('objectstorage'), 'Object-Storage')
+      assert.equal(helpers.getBluemixServiceLabel('objectStorage'), 'Object-Storage')
     })
 
     it('get label for appid', function () {
-      assert.equal(helpers.getBluemixServiceLabel('appid'), 'AppID')
+      assert.equal(helpers.getBluemixServiceLabel('auth'), 'AppID')
     })
 
     it('get label for watsonconversation', function () {
-      assert.equal(helpers.getBluemixServiceLabel('watsonconversation'), 'conversation')
+      assert.equal(helpers.getBluemixServiceLabel('conversation'), 'conversation')
     })
 
     it('get label for alertnotification', function () {
-      assert.equal(helpers.getBluemixServiceLabel('alertnotification'), 'AlertNotification')
+      assert.equal(helpers.getBluemixServiceLabel('alertNotification'), 'AlertNotification')
     })
 
     it('get label for pushnotifications', function () {
-      assert.equal(helpers.getBluemixServiceLabel('pushnotifications'), 'imfpush')
+      assert.equal(helpers.getBluemixServiceLabel('push'), 'imfpush')
     })
 
     it('get label for unrecognised value', function () {
@@ -400,23 +401,23 @@ describe('Unit tests for helpers', function () {
     })
 
     it('get default plan for objectstorage', function () {
-      assert.equal(helpers.getBluemixDefaultPlan('objectstorage'), 'Free')
+      assert.equal(helpers.getBluemixDefaultPlan('objectStorage'), 'Free')
     })
 
     it('get default plan for appid', function () {
-      assert.equal(helpers.getBluemixDefaultPlan('appid'), 'Graduated tier')
+      assert.equal(helpers.getBluemixDefaultPlan('auth'), 'Graduated tier')
     })
 
     it('get default plan for watsonconversation', function () {
-      assert.equal(helpers.getBluemixDefaultPlan('watsonconversation'), 'free')
+      assert.equal(helpers.getBluemixDefaultPlan('conversation'), 'free')
     })
 
     it('get default plan for alertnotification', function () {
-      assert.equal(helpers.getBluemixDefaultPlan('alertnotification'), 'authorizedusers')
+      assert.equal(helpers.getBluemixDefaultPlan('alertNotification'), 'authorizedusers')
     })
 
     it('get default plan for pushnotifications', function () {
-      assert.equal(helpers.getBluemixDefaultPlan('pushnotifications'), 'lite')
+      assert.equal(helpers.getBluemixDefaultPlan('push'), 'lite')
     })
 
     it('get default plan for unrecognised value', function () {

--- a/test/unit/refresh.js
+++ b/test/unit/refresh.js
@@ -141,7 +141,7 @@ describe('Unit tests for swiftserver:refresh', function () {
                                 appName: 'myapp',
                                 bluemix: {
                                   backendPlatform: 'SWIFT',
-                                  objectStorage: [{ serviceInfo: {} }]
+                                  objectStorage: [{ serviceInfo: {label: 'Object-Storage'} }]
                                 }
                               }
                             })
@@ -361,7 +361,6 @@ describe('Unit tests for swiftserver:refresh', function () {
           models: [ todoModel ],
           docker: true,
           bluemix: {
-            // TODO change this to serviceInfo format!
             backendPlatform: 'SWIFT',
             auth: { serviceInfo: { name: 'myAppIDService' } },
             cloudant: [{ serviceInfo: { name: 'myCloudantService' } }],


### PR DESCRIPTION
Two dependencies of the project (generator-ibm-service-enablement and generator-ibm-cloud-enablement) use a different "bluemix" object to specify the cloud properties than we were using previously in this generator.

When we shifted to using these dependencies for generating cloud related content we kept our original format for specifying services intact to reduce the churn and risk associated with the refactor.

The time has come to address that technical debt and update the generators to use the bluemix object everywhere and remove the legacy format and associated conversion code.