### PR TITLE
fix: add url to Push Notifications service

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -864,9 +864,9 @@ module.exports = Generator.extend({
           }
         }
         switch (answers.pushNotificationsRegion) {
-          case 'United Kingdom': this.bluemix.server.domain = 'eu-gb.bluemix.net'; break
-          case 'Sydney': this.bluemix.server.domain = 'au-syd.bluemix.net'; break
-          case 'US South': this.bluemix.server.domain = 'ng.bluemix.net'; break
+          case 'US South': this.services.push.url = 'http://imfpush.ng.bluemix.net'; break
+          case 'United Kingdom': this.services.push.url = 'http://imfpush.eu-gb.bluemix.net'; break
+          case 'Sydney': this.services.push.url = 'http://imfpush.au-syd.bluemix.net'; break
           default:
             this.env.error(chalk.red(`Internal error: unknown region ${answers.pushNotificationsRegion}`))
         }

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "chalk": "^2.1.0",
     "debug": "^3.0.0",
     "generator-ibm-cloud-enablement": "0.0.114",
-    "generator-ibm-service-enablement": "0.1.0",
+    "generator-ibm-service-enablement": "0.6.0",
     "handlebars": "^4.0.5",
     "ibm-openapi-support": "^0.0.9",
     "js-yaml": "^3.9.1",

--- a/refresh/templates/common/Package.swift
+++ b/refresh/templates/common/Package.swift
@@ -6,8 +6,8 @@ let package = Package(
     dependencies: [
       .package(url: "https://github.com/IBM-Swift/Kitura.git", .upToNextMinor(from: "2.0.0")),
       .package(url: "https://github.com/IBM-Swift/HeliumLogger.git", .upToNextMinor(from: "1.7.1")),
-      .package(url: "https://github.com/IBM-Swift/CloudEnvironment.git", .upToNextMinor(from: "4.0.5")),
-      .package(url: "https://github.com/IBM-Swift/Configuration.git", .upToNextMinor(from: "1.0.0")),
+      .package(url: "https://github.com/IBM-Swift/CloudEnvironment.git", from: "6.0.0"),
+      .package(url: "https://github.com/IBM-Swift/Configuration.git", from: "3.0.0"),
 <%  dependencies.forEach(function(dependency) { -%>
       <%- dependency %>
 <%  }) -%>

--- a/test/integration/app/prompted_build.js
+++ b/test/integration/app/prompted_build.js
@@ -188,7 +188,7 @@ describe('Integration tests (prompt build) for swiftserver:app', function () {
     describe('with all capabilities and services', function () {
       // On macOS this test sometimes times out because of the number
       // of dependencies to fetch and compile. Use a longer timeout.
-      this.timeout(500000)
+      this.timeout(600000)
 
       // var petstoreSDKName = 'Swagger_Petstore'
       var petstoreSwaggerFile = path.join(__dirname, '../../resources/petstore.yaml')

--- a/test/integration/app/prompted_nobuild.js
+++ b/test/integration/app/prompted_nobuild.js
@@ -1201,12 +1201,8 @@ describe('Integration tests (prompt no build) for swiftserver:app', function () 
         commonTest.pushnotifications.itCreatedServiceFilesWithExpectedContent('myPushNotificationsService', {
           app_guid: 'myAppGuid',
           app_secret: 'myAppSecret',
-          client_secret: ''
-        })
-
-        it(`push notifications boilerplate contains correct region`, function () {
-          var serviceFile = `${commonTest.servicesSourceDir}/ServicePush.swift`
-          assert.fileContent(serviceFile, 'bluemixRegion: PushNotifications.Region.UK')
+          client_secret: '',
+          url: 'http://imfpush.eu-gb.bluemix.net'
         })
       })
     })

--- a/test/lib/common_test.js
+++ b/test/lib/common_test.js
@@ -676,9 +676,9 @@ exports.alertnotification = {
       var serviceFile = `${exports.servicesSourceDir}/${sourceFile}`
       assert.fileContent([
         [serviceFile, 'import AlertNotifications'],
-        [serviceFile, 'let serviceCredentials = ServiceCredentials('],
+        [serviceFile, 'let alertNotificationCredentials = cloudEnv.getAlertNotificationCredentials('],
         [serviceFile, 'func initializeServiceAlertNotification(cloudEnv: CloudEnv) throws'],
-        [serviceFile, 'return serviceCredentials']
+        [serviceFile, 'return alertNotificationCredentials']
       ])
     })
   }

--- a/test/unit/app.js
+++ b/test/unit/app.js
@@ -1603,14 +1603,14 @@ describe('Unit tests for swiftserver:app', function () {
             appType: 'scaffold',
             appName: applicationName,
             capabilities: [],
-            bluemix: { server: { domain: 'ng.bluemix.net' } },
             services: {
               push: {
                 serviceInfo: {
                   name: 'myPushNotificationsService'
                 },
                 appGuid: 'myAppGuid',
-                appSecret: 'myAppSecret'
+                appSecret: 'myAppSecret',
+                url: 'http://imfpush.ng.bluemix.net'
               }
             }
           }))


### PR DESCRIPTION
Removing PushSDK region from `bluemix.server.domain` and instead creating Push Notifications URL for Prompting. For scaffolder, we are given the Push URL.

Updating unit and integration tests.