### PR TITLE
fix(package): update generator-ibm-cloud-enablement to version 0.6.10

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "bluebird": "^3.5.0",
     "chalk": "^2.1.0",
     "debug": "^3.0.0",
-    "generator-ibm-cloud-enablement": "0.0.114",
+    "generator-ibm-cloud-enablement": "0.6.10",
     "generator-ibm-service-enablement": "0.6.1",
     "handlebars": "^4.0.5",
     "ibm-openapi-support": "^0.0.9",


### PR DESCRIPTION
Closes #387