### PR TITLE
fix: make RouteTests more lenient on index content

### DIFF
--- a/refresh/templates/common/RouteTests.swift
+++ b/refresh/templates/common/RouteTests.swift
@@ -47,7 +47,7 @@ class RouteTests: XCTestCase {
             .sendForTestingWithKitura { data, statusCode in
                 if let getResult = String(data: data, encoding: String.Encoding.utf8){
                     XCTAssertEqual(statusCode, 200)
-                    XCTAssertTrue(getResult.contains("<html>"))
+                    XCTAssertTrue(getResult.contains("<html"))
                     XCTAssertTrue(getResult.contains("</html>"))
                 } else {
                     XCTFail("Return value from / was nil!")


### PR DESCRIPTION
For example when the `html` element has attributes.