### PR TITLE
fixed init special chars

### DIFF
--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -57,7 +57,7 @@ exports.validateDirName = function (name) {
   if (!name) {
     return 'Name is required'
   }
-  return validateValue(name, /[/@\s+%:]/)
+  return validateValue(name, /[/@\s+%:.;,?&=+$]/)
 }
 
 exports.validateRequiredCredential = function (name) {
@@ -120,7 +120,7 @@ exports.validateAppName = function (name) {
   if (name.toLowerCase() === 'favicon.ico') {
     return format('Application name cannot be {favicon.ico}')
   }
-  return validateValue(name, /[/@\s+%:]/)
+  return validateValue(name, /[/@\s+%:.;,?&=+$]/)
 }
 
 /**
@@ -206,7 +206,7 @@ exports.validateRequiredName = function (name) {
   if (!name) {
     return format('Name is required.')
   }
-  return validateValue(name, /[/@\s+%:.]/)
+  return validateValue(name, /[/@\s+%:.;,?&=+$]/)
 }
 
 /*
@@ -236,7 +236,7 @@ exports.validateNewModel = function (name) {
  */
 function validateValue (name, unallowedCharacters) {
   if (!unallowedCharacters) {
-    unallowedCharacters = /[/@\s+%:.]/
+    unallowedCharacters = /[/@\s+%:.;,?&=+$]/
   }
   if (name.match(unallowedCharacters)) {
     return format('The name %s cannot contain special characters (regex %s)',

--- a/test/unit/app.js
+++ b/test/unit/app.js
@@ -425,10 +425,10 @@ describe('Unit tests for swiftserver:app', function () {
         runContext = helpers.run(appGeneratorPath)
                             .withGenerators(dependentGenerators)
                             .inTmpDir(function (tmpDir) {
-                              this.inDir(path.join(tmpDir, 'inva&%*lid'))
+                              this.inDir(path.join(tmpDir, 'inva[%*lid'))
                             })
                             .withOptions({ testmode: true })
-                            .withArguments(['inva&%*lid'])
+                            .withArguments(['inva[%*lid'])
         return runContext.toPromise()
       })
 
@@ -500,6 +500,35 @@ describe('Unit tests for swiftserver:app', function () {
       capabilities: [ 'docker', 'metrics' ],
       services: {}
     }))
+  })
+
+  describe('in dir with invalid and sanitizable name using --init', function () {
+    var runContext
+
+    before(function () {
+      runContext = helpers.run(appGeneratorPath)
+      .withGenerators(dependentGenerators)
+      .inTmpDir(function (tmpDir) {
+        this.inDir(path.join(tmpDir, 'i-n v&a%l@i$d s.y;m,b?o=l+s'))
+      })
+      .withOptions({ testmode: true, init: true })
+      return runContext.toPromise()
+    })
+
+    after(function () {
+      runContext.cleanTestDirectory()
+    })
+
+    commonTest.itUsedDestinationDirectory('i-n-v-a-l-i-d-s-y-m-b-o-l-s')
+
+    it('created a spec object with appName defaulting to dir and no appDir', function () {
+      var spec = runContext.generator.spec
+      var expectedSpec = {
+        appName: 'i-n-v-a-l-i-d-s-y-m-b-o-l-s',
+        appDir: undefined
+      }
+      assert.objectContent(spec, expectedSpec)
+    })
   })
 
   describe('--enableUsecase specified', function () {


### PR DESCRIPTION
Fix for issue #437.
The init option was no handling hyphen in project name correctly. The generator was using the yoman name for the init option which replaces all special characters with spaces. This is different from our generator which replaces special characters with dashes. 

I have moved the generate project name above the init spec so that the name is generated and then used for the init. I have also made the init function create a new directory if the name is changed. 

These changes with make the init function act the same as accepting all default parameters when going through yo swiftserver. 

I have also added some extra special characters to be replaced with dashes for the name function and corrected the comments.

A test for this fix has added and all npm tests are passing.