### PR TITLE
fix: update health routes to be codable

### DIFF
--- a/refresh/templates/common/HealthRoutes.swift
+++ b/refresh/templates/common/HealthRoutes.swift
@@ -1,12 +1,15 @@
 import LoggerAPI
+import Health
+import KituraContracts
 
 func initializeHealthRoutes(app: App) {
-    app.router.get("/health") { request, response, _ in
-        let result = health.status.toSimpleDictionary()
+    
+    app.router.get("/health") { (respondWith: (Status?, RequestError?) -> Void) -> Void in
         if health.status.state == .UP {
-            try response.send(json: result).end()
+            respondWith(health.status, nil)
         } else {
-            try response.status(.serviceUnavailable).send(json: result).end()
+            respondWith(health.status, .serviceUnavailable)
         }
     }
+    
 }

--- a/refresh/templates/common/RouteTests.swift
+++ b/refresh/templates/common/RouteTests.swift
@@ -60,30 +60,24 @@ class RouteTests: XCTestCase {
     }
     
     func testHealthRoute() {
-        
         let printExpectation = expectation(description: "The /health route will print UP, followed by a timestamp.")
         
         URLRequest(forTestWithMethod: "GET", route: "health")?
             .sendForTestingWithKitura { data, statusCode in
                 if let getResult = String(data: data, encoding: String.Encoding.utf8) {
                     XCTAssertEqual(statusCode, 200)
-                    XCTAssertTrue(getResult.contains("UP"))
+                    XCTAssertTrue(getResult.contains("UP"), "UP not found in the result.")
                     let date = Date()
                     let calendar = Calendar.current
                     let yearString = String(describing: calendar.component(.year, from: date))
-                    XCTAssertTrue(getResult.contains(yearString)
+                    XCTAssertTrue(getResult.contains(yearString), "Failed to create String from date. Date is either missing or incorrect.")
                 } else {
-                    XCTFail("Return value from /health was nil, or was not UP, or had no timestamp.")
+                    XCTFail("Unable to convert request Data to String.")
                 }
-                
                 printExpectation.fulfill()
-                
         }
-        
         waitForExpectations(timeout: 10.0, handler: nil)
-        
     }
-    
 }
     
     

--- a/refresh/templates/common/RouteTests.swift
+++ b/refresh/templates/common/RouteTests.swift
@@ -68,7 +68,10 @@ class RouteTests: XCTestCase {
                 if let getResult = String(data: data, encoding: String.Encoding.utf8) {
                     XCTAssertEqual(statusCode, 200)
                     XCTAssertTrue(getResult.contains("UP"))
-                    XCTAssertTrue(getResult.contains("2017") || getResult.contains("2018") || getResult.contains("2019"))
+                    let date = Date()
+                    let calendar = Calendar.current
+                    let yearString = String(describing: calendar.component(.year, from: date))
+                    XCTAssertTrue(getResult.contains(yearString)
                 } else {
                     XCTFail("Return value from /health was nil, or was not UP, or had no timestamp.")
                 }
@@ -85,7 +88,7 @@ class RouteTests: XCTestCase {
     
     
 
-}
+
 
 
 private extension URLRequest {

--- a/refresh/templates/common/RouteTests.swift
+++ b/refresh/templates/common/RouteTests.swift
@@ -58,6 +58,32 @@ class RouteTests: XCTestCase {
 
         waitForExpectations(timeout: 10.0, handler: nil)
     }
+    
+    func testHealthRoute() {
+        
+        let printExpectation = expectation(description: "The /health route will print UP, followed by a timestamp.")
+        
+        URLRequest(forTestWithMethod: "GET", route: "health")?
+            .sendForTestingWithKitura { data, statusCode in
+                if let getResult = String(data: data, encoding: String.Encoding.utf8) {
+                    XCTAssertEqual(statusCode, 200)
+                    XCTAssertTrue(getResult.contains("UP"))
+                    XCTAssertTrue(getResult.contains("2017") || getResult.contains("2018") || getResult.contains("2019"))
+                } else {
+                    XCTFail("Return value from /health was nil, or was not UP, or had no timestamp.")
+                }
+                
+                printExpectation.fulfill()
+                
+        }
+        
+        waitForExpectations(timeout: 10.0, handler: nil)
+        
+    }
+    
+}
+    
+    
 
 }
 


### PR DESCRIPTION
Updated the health routes file to leverage codable routing, no regression as the behavior is the same as before, it returns two items if theres an issue and one if there isn't.