### PR TITLE
fix: localhost and port for client SDK

### DIFF
--- a/refresh/templates/common/productSwagger.yaml
+++ b/refresh/templates/common/productSwagger.yaml
@@ -10,6 +10,8 @@ consumes:
 produces:
   - application/json
 
+host: localhost:8080
+
 paths:
   /products:
     get:


### PR DESCRIPTION
This addition has been requested by @mjperrins to facilitate adoption of the client SDK.
Currently, if I drop the SDK into the client app, the asset's plist doesn't point to localhost:8080.

This change produces the following result in the generated SDK's plist file:
<img width="895" alt="screen shot 2018-03-09 at 10 19 17 pm" src="https://user-images.githubusercontent.com/18534315/37238387-dd2ff64a-23ea-11e8-9ff1-d4a626799b16.png">
