### PR TITLE
fix: hypersecure mongodb credential support

### DIFF
--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -478,6 +478,11 @@ function sanitizeCredentialsAndFillInDefaults (serviceType, service) {
       }
     case 'autoscaling':
       return {}
+    case 'hypersecuredb':
+      return {
+        url: service.url || '',
+        cert: service.cert || ''
+      }
     default:
       return {}
   }

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "chalk": "^2.1.0",
     "debug": "^3.0.0",
     "generator-ibm-cloud-enablement": "0.8.9",
-    "generator-ibm-service-enablement": "0.8.1",
+    "generator-ibm-service-enablement": "0.9.2",
     "generator-ibm-usecase-enablement": "3.2.0",
     "handlebars": "^4.0.5",
     "ibm-openapi-support": "0.0.10",


### PR DESCRIPTION
Closes #471.

This passthrough of credentials allows the hypersecure mongodb service to be utilized when combined with the latest service-enablement release.