### PR TITLE
fix: sdk generation migration

### DIFF
--- a/config.js
+++ b/config.js
@@ -17,7 +17,7 @@
 'use strict'
 var config = {}
 
-config.sdkGenURL = 'https://mobilesdkgen.ng.bluemix.net/sdkgen/api/generator/'
+config.sdkGenURL = 'https://us-south.devex.bluemix.net/sdkgen/api/generator/'
 config.sdkGenCheckDelay = 3000
 
 module.exports = config


### PR DESCRIPTION
The endpoint used for generating SDKs is changing - the new one is now live, and this PR addresses the migration.