### PR TITLE
docs(readme): Add in Kubernetes, mappings.json and make 'Run' more prominent 

### DIFF
--- a/refresh/index.js
+++ b/refresh/index.js
@@ -1087,6 +1087,7 @@ module.exports = Generator.extend({
           {
             appName: this.projectName,
             executableName: this.executableModule,
+            chartName: helpers.sanitizeAppName(this.bluemix.name),
             generatorVersion: this.generatorVersion,
             web: this.web,
             docker: this.docker,

--- a/refresh/templates/common/README.scaffold.md
+++ b/refresh/templates/common/README.scaffold.md
@@ -2,6 +2,16 @@
 
 This scaffolded application provides a starting point for creating Swift applications running on [Kitura](http://www.kitura.io/).
 
+### Table of Contents
+* [Requirements](#requirements)
+* [Project contents](#project-contents)
+* [Run](#run)
+* [Configuration](#configuration)
+* [Deploy to IBM Cloud](#deploy-to-ibm-cloud)
+* [Service descriptions](#service-descriptions)
+* [License](#license)
+* [Generator](#generator)
+
 #### Project contents
 This application has been generated with the following capabilities and services, which are described in full in their respective sections below:
 
@@ -111,7 +121,7 @@ You can also set up a default IBM Cloud Toolchain to handle deploying your appli
 
 [![Create Toolchain](https://console.ng.bluemix.net/devops/graphics/create_toolchain_button.png)](https://console.ng.bluemix.net/devops/setup/deploy/)
 
-### Project Contents
+### Service descriptions
 <% if (web) { -%>
 #### Static web file serving
 This application includes a `public` directory in the root of the project. The contents of this directory will be served as static content using the built-in Kitura [StaticFileServer module](https://github.com/IBM-Swift/Kitura/wiki/Serving-Static-Content).

--- a/refresh/templates/common/README.scaffold.md
+++ b/refresh/templates/common/README.scaffold.md
@@ -1,26 +1,9 @@
 ## Scaffolded Swift Kitura server application
 
-[![](https://img.shields.io/badge/IBM%20Cloud-powered-blue.svg)](https://bluemix.net)
-[![Platform](https://img.shields.io/badge/platform-swift-lightgrey.svg?style=flat)](https://developer.ibm.com/swift/)
-
-### Table of Contents
-* [Summary](#summary)
-* [Requirements](#requirements)
-* [Project contents](#project-contents)
-* [Configuration](#configuration)
-* [Run](#run)
-* [Deploy to IBM Cloud](#deploy-to-ibm-cloud)
-* [License](#license)
-* [Generator](#generator)
-
-### Summary
 This scaffolded application provides a starting point for creating Swift applications running on [Kitura](http://www.kitura.io/).
 
-### Requirements
-* [Swift 4](https://swift.org/download/)
-
-### Project contents
-This application has been generated with the following capabilities and services:
+#### Project contents
+This application has been generated with the following capabilities and services, which are described in full in their respective sections below:
 
 * [CloudEnvironment](#configuration)
 <% if (web) { -%>
@@ -65,6 +48,70 @@ This application has been generated with the following capabilities and services
 * [Auto-scaling](#auto-scaling)
 <% } -%>
 
+
+### Requirements
+* [Swift 4](https://swift.org/download/)
+
+### Run
+To build and run the application:
+1. `swift build`
+1. `.build/debug/<%- executableName %>`
+
+<% if (docker) { -%>
+#### Docker
+A description of the files related to Docker can be found in the [Docker files](#docker-files) setion. To build the two docker images, run the following commands from the root directory of the project:
+* `docker build -t myapp-run .`
+* `docker build -t myapp-build -f Dockerfile-tools .`
+You may customize the names of these images by specifying a different value after the `-t` option.
+
+To compile the application using the tools docker image, run:
+* `docker run -v $PWD:/swift-project -w /swift-project myapp-build /swift-utils/tools-utils.sh build release`
+
+To run the application:
+* `docker run -it -p 8080:8080 -v $PWD:/swift-project -w /swift-project myapp-run sh -c .build-ubuntu/release/<%- executableName %>`
+
+
+#### Kubernetes
+To deploy your application to your Kubernetes cluster, run `helm install --name myapp .` in the `/chart/<%- chartName %>` directory. You need to make sure you change the `repository` variable in your `chart/<%- chartName %>/values.yaml` file points to the docker image containing your runnable application.
+<% } -%>
+
+### Configuration
+Your application configuration information for any services is stored in the `localdev-config.json` file in the `config` directory. This file is in the `.gitignore` to prevent sensitive information from being stored in git. The connection information for any configured services that you would like to access when running locally, such as username, password and hostname, is stored in this file.
+
+The application uses the [CloudEnvironment package](https://github.com/IBM-Swift/CloudEnvironment) to read the connection and configuration information from the environment and this file. It uses `mappings.json`, found in the `config` directory, to communicate where the credentials can be found for each service.
+
+If the application is running locally, it can connect to IBM Cloud services using unbound credentials read from this file. If you need to create unbound credentials you can do so from the IBM Cloud web console ([example](https://console.ng.bluemix.net/docs/services/Cloudant/tutorials/create_service.html#creating-a-service-instance)), or using the CloudFoundry CLI [`cf create-service-key` command](http://cli.cloudfoundry.org/en-US/cf/create-service-key.html).
+
+When you push your application to IBM Cloud, these values are no longer used, instead the application automatically connects to bound services using environment variables.
+
+#### Iterative Development
+The `iterative-dev.sh` script is included in the root of the generated Swift project and allows for fast & easy iterations for the developer. Instead of stopping the running Kitura server to see new code changes, while the script is running, it will automatically detect changes in the project's **.swift** files and recompile the app accordingly.
+
+To use iterative development:
+* For native OS, execute the `./iterative-dev.sh` script from the root of the project.
+<% if (docker) { -%>
+* With docker, shell into the tools container mentioned above, and run the `./swift-project/iterative-dev.sh` script.  File system changes are detected using a low-tech infinitely looping poll mechanism, which works in both local OS/filesystem and across host OS->Docker container volume scenarios.
+<% } -%>
+
+### Deploy to IBM Cloud
+You can deploy your application to Bluemix using:
+* the [CloudFoundry CLI](#cloudfoundry-cli)
+* an [IBM Cloud toolchain](#ibm-cloud-toolchain)
+
+#### CloudFoundry CLI
+You can deploy the application to IBM Cloud using the CloudFoundry command-line:
+1. Install the Cloud Foundry command-line (https://docs.cloudfoundry.org/cf-cli/install-go-cli.html)
+1. Ensure all configured services have been provisioned
+1. Run `cf push` from the project root directory
+
+The Cloud Foundry CLI will not provision the configured services for you, so you will need to do this manually using the IBM Cloud web console ([example](https://console.ng.bluemix.net/docs/services/Cloudant/tutorials/create_service.html#creating-a-service-instance)) or the CloudFoundry CLI (`cf create-service` command)[http://cli.cloudfoundry.org/en-US/cf/create-service.html]. The service names and types will need to match your [configuration](#configuration).
+
+#### IBM Cloud toolchain
+You can also set up a default IBM Cloud Toolchain to handle deploying your application to IBM Cloud. This is achieved by publishing your application to a publicly accessible github repository and using the "Create Toolchain" button below. In this case configured services will be automatically provisioned, once, during toolchain creation.
+
+[![Create Toolchain](https://console.ng.bluemix.net/devops/graphics/create_toolchain_button.png)](https://console.ng.bluemix.net/devops/setup/deploy/)
+
+### Project Contents
 <% if (web) { -%>
 #### Static web file serving
 This application includes a `public` directory in the root of the project. The contents of this directory will be served as static content using the built-in Kitura [StaticFileServer module](https://github.com/IBM-Swift/Kitura/wiki/Serving-Static-Content).
@@ -106,7 +153,7 @@ The `Dockerfile` defines the specification of the default docker image for runni
 
 The `Dockerfile-tools` is a docker specification file similar to the `Dockerfile`, except it includes the tools required for compiling the application. This image can be used to compile the application.
 
-Details on how to build the docker images, compile and run the application within the docker image can be found in the [Run section](#run) below.
+Details on how to build the docker images, compile and run the application within the docker image can be found in the [Run section](#run).
 <% } -%>
 #### IBM Cloud deployment
 Your application has a set of cloud deployment configuration files defined to support deploying your application to IBM Cloud:
@@ -196,67 +243,6 @@ This application uses the [SwiftMetrics package](https://github.com/RuntimeTools
 
 The connection details for this client are loaded by the [configuration](#configuration) code and are passed to the SwiftMetrics auto-scaling client in the boilerplate code.
 <% } -%>
-
-### Configuration
-Your application configuration information is stored in the `config.json` in the project root directory. This file is in the `.gitignore` to prevent sensitive information from being stored in git.
-
-The connection information for any configured services, such as username, password and hostname, is stored in this file.
-
-The application uses the [CloudEnvironment package](https://github.com/IBM-Swift/CloudEnvironment) to read the connection and configuration information from the environment and this file.
-
-If the application is running locally, it can connect to IBM Cloud services using unbound credentials read from this file. If you need to create unbound credentials you can do so from the IBM Cloud web console ([example](https://console.ng.bluemix.net/docs/services/Cloudant/tutorials/create_service.html#creating-a-service-instance)), or using the CloudFoundry CLI [`cf create-service-key` command](http://cli.cloudfoundry.org/en-US/cf/create-service-key.html).
-
-When you push your application to IBM Cloud, these values are no longer used, instead the application automatically connects to bound services using environment variables.
-
-### Run
-To build and run the application:
-1. `swift build`
-1. `.build/debug/<%- executableName %>`
-
-<% if (metrics) { -%>
-**NOTE**: On macOS you will need to add options to the `swift build` command: `swift build -Xlinker -lc++`
-<% } -%>
-
-<% if (docker) { -%>
-#### Docker
-To build the two docker images, run the following commands from the root directory of the project:
-* `docker build -t myapp-run .`
-* `docker build -t myapp-build -f Dockerfile-tools .`
-You may customize the names of these images by specifying a different value after the `-t` option.
-
-To compile the application using the tools docker image, run:
-* `docker run -v $PWD:/swift-project -w /swift-project myapp-build /swift-utils/tools-utils.sh build release`
-
-To run the application:
-* `docker run -it -p 8080:8080 -v $PWD:/swift-project -w /swift-project myapp-run sh -c .build-ubuntu/release/<%- executableName %>`
-<% } -%>
-
-#### Iterative Development
-The `iterative-dev.sh` script is included in the root of the generated Swift project and allows for fast & easy iterations for the developer. Instead of stopping the running Kitura server to see new code changes, while the script is running, it will automatically detect changes in the project's **.swift** files and recompile the app accordingly.
-
-To use iterative development:
-* For native OS, execute the `./iterative-dev.sh` script from the root of the project.
-<% if (docker) { -%>
-* With docker, shell into the tools container mentioned above, and run the `./swift-project/iterative-dev.sh` script.  File system changes are detected using a low-tech infinitely looping poll mechanism, which works in both local OS/filesystem and across host OS->Docker container volume scenarios.
-<% } -%>
-
-### Deploy to IBM Cloud
-You can deploy your application to Bluemix using:
-* the [CloudFoundry CLI](#cloudfoundry-cli)
-* an [IBM Cloud toolchain](#ibm-cloud-toolchain)
-
-#### CloudFoundry CLI
-You can deploy the application to IBM Cloud using the CloudFoundry command-line:
-1. Install the Cloud Foundry command-line (https://docs.cloudfoundry.org/cf-cli/install-go-cli.html)
-1. Ensure all configured services have been provisioned
-1. Run `cf push` from the project root directory
-
-The Cloud Foundry CLI will not provision the configured services for you, so you will need to do this manually using the IBM Cloud web console ([example](https://console.ng.bluemix.net/docs/services/Cloudant/tutorials/create_service.html#creating-a-service-instance)) or the CloudFoundry CLI (`cf create-service` command)[http://cli.cloudfoundry.org/en-US/cf/create-service.html]. The service names and types will need to match your [configuration](#configuration).
-
-#### IBM Cloud toolchain
-You can also set up a default IBM Cloud Toolchain to handle deploying your application to IBM Cloud. This is achieved by publishing your application to a publicly accessible github repository and using the "Create Toolchain" button below. In this case configured services will be automatically provisioned, once, during toolchain creation.
-
-[![Create Toolchain](https://console.ng.bluemix.net/devops/graphics/create_toolchain_button.png)](https://console.ng.bluemix.net/devops/setup/deploy/)
 
 ### License
 All generated content is available for use and modification under the permissive MIT License (see `LICENSE` file), with the exception of SwaggerUI which is licensed under an Apache-2.0 license (see `NOTICES.txt` file).


### PR DESCRIPTION
- Add in Kubernetes section (plus export chart name to use in README)
- Add info about `mappings.json` to Configuration section.
- Move Run section further up page
- Remove badges (links often broken)