### PR TITLE
[WIP] fix: push notifications SDK and credentials changes

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -954,7 +954,7 @@ module.exports = Generator.extend({
       var prompts = [
         { name: 'pushNotificationsName', message: 'Enter service name (blank for default):' },
         { name: 'pushNotificationsAppGuid', message: 'Enter app GUID:' },
-        { name: 'pushNotificationsAppSecret', message: 'Enter app secret:', type: 'password' },
+        { name: 'pushNotificationsAPIKey', message: 'Enter API key:', type: 'password' },
         {
           name: 'pushNotificationsRegion',
           type: 'list',
@@ -967,7 +967,7 @@ module.exports = Generator.extend({
         var pushService = this.services.push
         this.services.push = {
           appGuid: answers.pushNotificationsAppGuid || undefined,
-          appSecret: answers.pushNotificationsAppSecret || undefined,
+          apikey: answers.pushNotificationsAPIKey || undefined,
           serviceInfo: {
             label: pushService.serviceInfo.label,
             name: answers.pushNotificationsName || pushService.serviceInfo.name,

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -486,7 +486,7 @@ function sanitizeCredentialsAndFillInDefaults (serviceType, service) {
         appGuid: service.appGuid || '',
         url: service.url || '',
         admin_url: service.admin_url || '',
-        appSecret: service.appSecret || '',
+        apikey: service.apikey || '',
         clientSecret: service.clientSecret || ''
       }
     case 'autoscaling':

--- a/refresh/templates/common/Package.swift
+++ b/refresh/templates/common/Package.swift
@@ -6,7 +6,7 @@ let package = Package(
     dependencies: [
       .package(url: "https://github.com/IBM-Swift/Kitura.git", .upToNextMinor(from: "2.5.0")),
       .package(url: "https://github.com/IBM-Swift/HeliumLogger.git", .upToNextMinor(from: "1.7.1")),
-      .package(url: "https://github.com/IBM-Swift/CloudEnvironment.git", from: "8.0.0"),
+      .package(url: "https://github.com/IBM-Swift/CloudEnvironment.git", from: "9.0.0"),
 <%  dependencies.forEach(function(dependency) { -%>
       <%- dependency %>
 <%  }) -%>

--- a/test/integration/app/prompted_nobuild.js
+++ b/test/integration/app/prompted_nobuild.js
@@ -1251,7 +1251,7 @@ describe('Integration tests (prompt no build) for swiftserver:app', function () 
         commonTest.itCreatedServiceConfigFiles()
         commonTest.pushnotifications.itCreatedServiceFilesWithExpectedContent('myPushNotificationsService', {
           appGuid: '',
-          appSecret: '',
+          apikey: '',
           clientSecret: ''
         })
       })
@@ -1270,7 +1270,7 @@ describe('Integration tests (prompt no build) for swiftserver:app', function () 
                                 configure: [ 'Push Notifications' ],
                                 pushNotificationsName: 'myPushNotificationsService',
                                 pushNotificationsAppGuid: 'myAppGuid',
-                                pushNotificationsAppSecret: 'myAppSecret',
+                                pushNotificationsAPIKey: 'myApiKey',
                                 pushNotificationsRegion: 'United Kingdom'
                               })
           return runContext.toPromise()
@@ -1283,7 +1283,7 @@ describe('Integration tests (prompt no build) for swiftserver:app', function () 
         commonTest.itCreatedServiceConfigFiles()
         commonTest.pushnotifications.itCreatedServiceFilesWithExpectedContent('myPushNotificationsService', {
           appGuid: 'myAppGuid',
-          appSecret: 'myAppSecret',
+          apikey: 'myApiKey',
           clientSecret: '',
           url: 'http://imfpush.eu-gb.bluemix.net'
         })

--- a/test/resources/unsupported_bluemix.json
+++ b/test/resources/unsupported_bluemix.json
@@ -385,7 +385,7 @@
     },
     "push": {
         "appGuid": "push-app-guid",
-        "appSecret": "push-app-secret",
+        "apikey": "push-apikey",
         "clientSecret": "push-client-secret",
         "serviceInfo": {
             "label": "push-label",

--- a/test/unit/app.js
+++ b/test/unit/app.js
@@ -1676,7 +1676,7 @@ describe('Unit tests for swiftserver:app', function () {
                                   configure: [ 'Push Notifications' ],
                                   pushNotificationsName: 'myPushNotificationsService',
                                   pushNotificationsAppGuid: 'myAppGuid',
-                                  pushNotificationsAppSecret: 'myAppSecret',
+                                  pushNotificationsAPIKey: 'myApiKey',
                                   pushNotificationsRegion: 'US South'
                                 })
             return runContext.toPromise()
@@ -1697,7 +1697,7 @@ describe('Unit tests for swiftserver:app', function () {
                   name: 'myPushNotificationsService'
                 },
                 appGuid: 'myAppGuid',
-                appSecret: 'myAppSecret',
+                apikey: 'myApiKey',
                 url: 'http://imfpush.ng.bluemix.net'
               }
             }

--- a/test/unit/helpers.js
+++ b/test/unit/helpers.js
@@ -143,7 +143,7 @@ describe('Unit tests for helpers', function () {
           appGuid: '',
           url: '',
           admin_url: '',
-          appSecret: '',
+          apikey: '',
           clientSecret: ''
         },
         autoscaling: {
@@ -209,7 +209,7 @@ describe('Unit tests for helpers', function () {
           appGuid: 'my-app-guid',
           url: 'http://my-host',
           admin_url: 'http://my-admin-host',
-          appSecret: 'my-app-secret',
+          apikey: 'my-apikey',
           clientSecret: 'my-client-secret'
         },
         autoscaling: {


### PR DESCRIPTION
This change accompanies changes in generator-ibm-service-enablement related to credential set changes for Push Notifications.

It is still a work in progress - this PR will only pass CI once the new version of service enablement is released, because of the Push Service instrumentation code needing to be updated with the new SDKs and constructors.