### PR TITLE
chore: fix unit test SDK generation mock requests

### DIFF
--- a/test/unit/refresh.js
+++ b/test/unit/refresh.js
@@ -1496,6 +1496,7 @@ describe('Unit tests for swiftserver:refresh', function () {
           var runContext
 
           before(function () {
+            mockSDKGen.mockClientSDKNetworkRequest(applicationName)
             runContext = helpers.run(refreshGeneratorPath)
                                 .withOptions({
                                   specObj: {
@@ -1562,6 +1563,7 @@ describe('Unit tests for swiftserver:refresh', function () {
           var runContext
 
           before(function () {
+            mockSDKGen.mockClientSDKNetworkRequest(applicationName)
             runContext = helpers.run(refreshGeneratorPath)
                                 .withOptions({
                                   specObj: {


### PR DESCRIPTION
Previously we were seeing intermittent issues where the SDK generation was timing out.  In the integration tests, we are hitting the sdkgen endpoint directly.  In the unit tests, we mock the sdkgen calls to return a dummy zip.  This was the part that has been consistently timing out in our Travis tests for the past few weeks.  This change ensures that we call the mocking request before running the tests, so that the mock requests are properly returning.