### PR TITLE
fix: addressing option handling for temporary devops pipeline workflow

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -187,7 +187,11 @@ module.exports = Generator.extend({
           repoType: 'clone',
           healthcheck: healthcheck,
           usecase: usecase,
-          starterOptions: starterOptions
+          starterOptions: starterOptions,
+          deploymentOrg: this.options.deploymentOrg,
+          deploymentSpace: this.options.deploymentSpace,
+          deploymentRegion: this.options.deploymentRegion,
+          toolchainName: this.options.toolchainName
         }
       } else if (this.options.init) {
         // User passed the --init flag, so no prompts, just generate basic default scaffold

--- a/refresh/index.js
+++ b/refresh/index.js
@@ -1406,10 +1406,10 @@ module.exports = Generator.extend({
         { force: this.force,
           bluemix: this.bluemix,
           repoType: this.repoType,
-          deploymentRegion: this.options.deploymentRegion,
-          deploymentOrg: this.options.deploymentOrg,
-          deploymentSpace: this.options.deploymentSpace,
-          toolchainName: this.options.toolchainName
+          deploymentRegion: this.spec.deploymentRegion,
+          deploymentOrg: this.spec.deploymentOrg,
+          deploymentSpace: this.spec.deploymentSpace,
+          toolchainName: this.spec.toolchainName
         })
     },
 

--- a/test/lib/common_test.js
+++ b/test/lib/common_test.js
@@ -64,9 +64,9 @@ exports.crudSourceFiles = [
 
 exports.bxdevConfigFile = 'cli-config.yml'
 exports.cloudFoundryManifestFile = 'manifest.yml'
-exports.deploymentRegion = '{{deploymentRegion}}'
-exports.deploymentSpace = '{{deploymentSpace}}'
-exports.deploymentOrg = '{{deploymentOrg}}'
+exports.deploymentRegion = '{{region}}'
+exports.deploymentSpace = '{{space}}'
+exports.deploymentOrg = '{{organization}}'
 exports.toolchainName = 'toolchainName'
 exports.cloudFoundryFiles = [ exports.cloudFoundryManifestFile, '.cfignore' ]
 exports.bluemixPipelineFile = '.bluemix/pipeline.yml'


### PR DESCRIPTION
The changes in the PR are a temporary changeset to support backwards compatibility with the DevOps v2 endpoint on IBM cloud.  Ultimately, these options will be embedded directly into the template in **generator-ibm-cloud-enablement**, but this sloppy workaround of passing these handlebars directly through (as opposed to a flag) will have to suffice in the short term.

Once v2 is rolled out across the IBM Cloud Tools CLI and UI, we can remove this logic.

Given that this is temporary, no test cases, documentation, or prompt flows have been added.  Prompt flows may be necessary for the final solution.