### PR TITLE
fix: Relax HeliumLogger dependency

### DIFF
--- a/refresh/templates/common/Package.swift
+++ b/refresh/templates/common/Package.swift
@@ -5,7 +5,7 @@ let package = Package(
     name: "{{{executableModule}}}",
     dependencies: [
       .package(url: "https://github.com/IBM-Swift/Kitura.git", .upToNextMinor(from: "2.5.0")),
-      .package(url: "https://github.com/IBM-Swift/HeliumLogger.git", .upToNextMinor(from: "1.7.1")),
+      .package(url: "https://github.com/IBM-Swift/HeliumLogger.git", from: "1.7.1"),
       .package(url: "https://github.com/IBM-Swift/CloudEnvironment.git", from: "9.0.0"),
 {{#each dependencies}}
       {{{this}}}


### PR DESCRIPTION
Removes the minor version constraint on HeliumLogger for generated projects.

### Context
Yesterday, we released a new 1.8.0 release of LoggerAPI and HeliumLogger.

Packages in the Kitura tree depend on only the major version of HeliumLogger (1.x), but for some reason the generated project depends on the minor (1.7).  This now causes package resolution to take a very long time, while SwiftPM eventually figures out that it needs to roll back to LoggerAPI 1.7.

There's no reason to depend on the minor of HeliumLogger.  (Arguably it makes sense to continue to depend on the minor of Kitura, as owners of generated projects may wish to opt in to newer Kitura releases).