### PR TITLE
fix: use the us-south sdk generation endpoint

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,6 @@ dist: trusty
 osx_image: xcode10
 before_install:
 - if [[ $TRAVIS_NODE_VERSION == "8" ]]; then npm install -g npm@4; fi
-- if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then rvm get head; fi
 - git clone https://github.com/IBM-Swift/Package-Builder.git
 - npm i -g makeshift
 - wget https://github.com/github/hub/releases/download/v2.2.9/hub-linux-386-2.2.9.tgz

--- a/config.js
+++ b/config.js
@@ -17,7 +17,7 @@
 'use strict'
 var config = {}
 
-config.sdkGenURL = 'https://global.devx.cloud.ibm.com/sdkgen/api/generator/'
+config.sdkGenURL = 'https://us-south.devx.cloud.ibm.com/sdkgen/api/generator/'
 config.sdkGenCheckDelay = 3000
 
 module.exports = config


### PR DESCRIPTION
In #651, I updated the SDK generation endpoint to use the `global` endpoint.  This has been causing problems, as the different microservice requests (creation, status checks, downloads) are often routed to different regions which do not have the information from the other regions where the previous calls have ended up.

This is being addressed by the microservice, but the immediate solution is to pick a regional endpoint and route all requests there.