### PR TITLE
feat: Kitura 2.8

### DIFF
--- a/refresh/index.js
+++ b/refresh/index.js
@@ -920,6 +920,10 @@ module.exports = Generator.extend({
         this.fs.copy(this.templatePath('common', 'InitializationError.swift'),
                      filepath)
       })
+      this._ifNotExistsInProject(['Sources', this.applicationModule, 'Logging.swift'], (filepath) => {
+        this.fs.copy(this.templatePath('common', 'Logging.swift'),
+                     filepath)
+      })
       this._ifNotExistsInProject(['Sources', this.applicationModule, 'Application.swift'], (filepath) => {
         this._writeHandlebarsFile('common/Application.swift', `Sources/${this.applicationModule}/Application.swift`,
           {

--- a/refresh/templates/common/Application.swift
+++ b/refresh/templates/common/Application.swift
@@ -56,6 +56,8 @@ public class App {
 {{/ifCond}}
 
     public init() throws {
+        // Configure logging
+        initializeLogging()
 {{#if appInitCode.metrics}}
         // Run the metrics initializer
         {{{appInitCode.metrics}}}

--- a/refresh/templates/common/Logging.swift
+++ b/refresh/templates/common/Logging.swift
@@ -1,0 +1,37 @@
+import Configuration
+import LoggerAPI
+import HeliumLogger
+
+/// Initialize logging using HeliumLogger, using the `LOG_LEVEL` environment
+/// variable. This must match the name of a `LoggerMessageType`, or `none` to
+/// disable logging entirely.
+///
+/// If no `LOG_LEVEL` is specified, the default level of `info` will be used.
+///
+func initializeLogging() {
+    let manager = ConfigurationManager()
+    manager.load(.environmentVariables)
+
+    let logLevel: LoggerMessageType
+    switch (manager["LOG_LEVEL"] as? String)?.lowercased() {
+    case "error":
+        logLevel = .error
+    case "warning":
+        logLevel = .warning
+    case "info":
+        logLevel = .info
+    case "verbose":
+        logLevel = .verbose
+    case "debug":
+        logLevel = .debug
+    case "exit":
+        logLevel = .exit
+    case "entry":
+        logLevel = .entry
+    case "none", "false", "off", "disabled":
+        return
+    default:
+        logLevel = .info
+    }
+    HeliumLogger.use(logLevel)
+}

--- a/refresh/templates/common/Package.swift
+++ b/refresh/templates/common/Package.swift
@@ -12,8 +12,8 @@ let package = Package(
 {{/each}}
     ],
     targets: [
-      .target(name: "{{{executableModule}}}", dependencies: [ .target(name: "{{{applicationModule}}}"), "Kitura" , "HeliumLogger"]),
-      .target(name: "{{{applicationModule}}}", dependencies: [ "Kitura", "CloudEnvironment",{{#each modules}}{{{this}}}, {{/each}}
+      .target(name: "{{{executableModule}}}", dependencies: [ .target(name: "{{{applicationModule}}}") ]),
+      .target(name: "{{{applicationModule}}}", dependencies: [ "Kitura", "HeliumLogger", "CloudEnvironment",{{#each modules}}{{{this}}}, {{/each}}
 {{#ifCond appType '===' 'crud'}}.target(name: "{{{generatedModule}}}"),{{/ifCond}}
 {{#ifCond sdkTargets.length '>' 0}}
       {{#each sdkTargets}}.target(name: "{{{this}}}"), {{/each}}
@@ -23,9 +23,9 @@ let package = Package(
       ]),
 {{/ifCond}}
 {{#ifCond appType '===' 'crud'}}
-      .target(name: "{{{generatedModule}}}", dependencies: ["Kitura", "CloudEnvironment","SwiftyJSON", {{#each modules}}{{{this}}},{{/each}}], path: "Sources/{{{generatedModule}}}"),
+      .target(name: "{{{generatedModule}}}", dependencies: ["Kitura", "CloudEnvironment", "SwiftyJSON", {{#each modules}}{{{this}}},{{/each}}], path: "Sources/{{{generatedModule}}}"),
 {{/ifCond}}
 
-      .testTarget(name: "ApplicationTests" , dependencies: [.target(name: "{{{applicationModule}}}"), "Kitura","HeliumLogger" ])
+      .testTarget(name: "ApplicationTests" , dependencies: [.target(name: "{{{applicationModule}}}"), "Kitura", "HeliumLogger" ])
     ]
 )

--- a/refresh/templates/common/Package.swift
+++ b/refresh/templates/common/Package.swift
@@ -4,7 +4,7 @@ import PackageDescription
 let package = Package(
     name: "{{{executableModule}}}",
     dependencies: [
-      .package(url: "https://github.com/IBM-Swift/Kitura.git", .upToNextMinor(from: "2.7.0")),
+      .package(url: "https://github.com/IBM-Swift/Kitura.git", .upToNextMinor(from: "2.8.0")),
       .package(url: "https://github.com/IBM-Swift/HeliumLogger.git", from: "1.7.1"),
       .package(url: "https://github.com/IBM-Swift/CloudEnvironment.git", from: "9.0.0"),
 {{#each dependencies}}

--- a/refresh/templates/common/main.swift
+++ b/refresh/templates/common/main.swift
@@ -1,12 +1,8 @@
-import Foundation
 import Kitura
 import LoggerAPI
-import HeliumLogger
 import {{{applicationModule}}}
 
 do {
-
-    HeliumLogger.use(LoggerMessageType.info)
 
     let app = try App()
     try app.run()


### PR DESCRIPTION
- Update Kitura dependency to 2.8.0,
- Move Logging configuration into a separate source file, introducing a `LOG_LEVEL` environment variable as a way to configure logging at runtime (suitable for defining in a Helm deployment).
- ~Update generator-ibm-cloud-enablement to `1.7.40` to pick up Dockerfile updates (https://github.com/ibm-developer/generator-ibm-cloud-enablement/pull/564)~ (edit: will be handled separately)